### PR TITLE
New default map

### DIFF
--- a/src/isar/config/default.ini
+++ b/src/isar/config/default.ini
@@ -62,7 +62,7 @@ url = https://echohubapi.equinor.com/api
 state_transitions_log_length = 50
 
 [maps]
-eq_robot_default_map_name = klab_compressor
+eq_robot_default_map_name = default_map
 eqrobot_maps_folder = src/isar/config/maps/
 
 [modules]

--- a/src/isar/config/maps/default_map.json
+++ b/src/isar/config/maps/default_map.json
@@ -1,0 +1,49 @@
+{
+  "map_name": "default_map",
+  "robot_reference_points": {
+    "points": [
+      {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "frame": "robot"
+      },
+      {
+        "x": 50.0,
+        "y": 100.0,
+        "z": 0.0,
+        "frame": "robot"
+      },
+      {
+        "x": 100.0,
+        "y": 50.0,
+        "z": 0.0,
+        "frame": "robot"
+      }
+    ],
+    "frame": "robot"
+  },
+  "asset_reference_points": {
+    "points": [
+      {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "frame": "asset"
+      },
+      {
+        "x": 50.0,
+        "y": 100.0,
+        "z": 0.0,
+        "frame": "asset"
+      },
+      {
+        "x": 100.0,
+        "y": 50.0,
+        "z": 0.0,
+        "frame": "asset"
+      }
+    ],
+    "frame": "asset"
+  }
+}


### PR DESCRIPTION
An attempt in resolving #63. Robot and asset reference points are now equal. Resulting in no conversion between the coordinate systems. The reference points are set to be the same z=0 plane, perhaps giving an easier visualisation for tests? 