### PR TITLE
Remove `mission_created_by` field from metadata

### DIFF
--- a/src/isar/models/mission_metadata/additional_metadata.py
+++ b/src/isar/models/mission_metadata/additional_metadata.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 map_echo_hub_api_to_metadata_keys = {
     "name": "mission_name",
-    "createdBy": "mission_created_by",
     "createdAt": "mission_created_at",
     "lastModified": "mission_last_modified",
     "robotOperator": "robot_operator",
@@ -13,7 +12,6 @@ map_echo_hub_api_to_metadata_keys = {
 class AdditionalMetadata:
     camera_type: str = ""
     mission_name: str = ""
-    mission_created_by: str = ""
     mission_created_at: str = ""
     mission_last_modified: str = ""
     robot_operator: str = ""

--- a/src/isar/storage/storage_service.py
+++ b/src/isar/storage/storage_service.py
@@ -209,7 +209,6 @@ class StorageService:
             "additional_metadata": {
                 "camera_type": mission.mission_metadata.additional_metadata.camera_type,
                 "mission_name": mission.mission_metadata.additional_metadata.mission_name,
-                "mission_created_by": mission.mission_metadata.additional_metadata.mission_created_by,
                 "mission_created_at": mission.mission_metadata.additional_metadata.mission_created_at,
                 "mission_last_modified": mission.mission_metadata.additional_metadata.mission_last_modified,
                 "robot_operator": mission.mission_metadata.additional_metadata.robot_operator,


### PR DESCRIPTION
We have no need for this information. Removed according to GDPR.

Resolves #94 