### PR TITLE
Log state transitions over multiple lines

### DIFF
--- a/src/isar/state_machine/states/cancel.py
+++ b/src/isar/state_machine/states/cancel.py
@@ -53,4 +53,16 @@ class Cancel(State):
         self.state_machine.to_next_state(next_state)
 
     def stop(self):
-        self.logger.info(f"State transitions: {self.state_machine.transitions_list}")
+        self._log_state_transitions()
+
+    def _log_state_transitions(self):
+        state_transitions: str = ", ".join(
+            [
+                f"\n  {transition}" if (i + 1) % 10 == 0 else f"{transition}"
+                for i, transition in enumerate(
+                    list(self.state_machine.transitions_list)
+                )
+            ]
+        )
+
+        self.logger.info(f"State transitions:\n  {state_transitions}")

--- a/src/isar/state_machine/states_enum.py
+++ b/src/isar/state_machine/states_enum.py
@@ -9,3 +9,6 @@ class States(str, Enum):
     Monitor = "monitor"
     Collect = "collect"
     Cancel = "cancel"
+
+    def __repr__(self):
+        return self.value


### PR DESCRIPTION
Cutoff value for newline in logging of state transitions is kept as a local variable, in order not to clutter the configuration file.

Closes #99.