### PR TITLE
Bug failed task causes state machine crash

### DIFF
--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -74,12 +74,9 @@ class Monitor(State):
             self.state_machine.current_task.status = task_status
 
             if self._task_completed(task=self.state_machine.current_task):
-                if isinstance(self.state_machine.current_task, InspectionTask):
-                    self._queue_inspections_for_upload(
-                        current_task=self.state_machine.current_task
-                    )
-
-                next_state = States.Send
+                next_state = self._process_finished_task(
+                    task=self.state_machine.current_task
+                )
                 break
             else:
                 self.task_status_thread = None
@@ -114,3 +111,9 @@ class Monitor(State):
             )
             return True
         return False
+
+    def _process_finished_task(self, task: Task) -> State:
+        if isinstance(task, InspectionTask):
+            self._queue_inspections_for_upload(current_task=task)
+
+        return States.Send

--- a/tests/isar/state_machine/states/test_monitor.py
+++ b/tests/isar/state_machine/states/test_monitor.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from isar.state_machine.states.monitor import Monitor

--- a/tests/isar/state_machine/states/test_monitor.py
+++ b/tests/isar/state_machine/states/test_monitor.py
@@ -1,5 +1,8 @@
+import time
+
 import pytest
 
+from isar.state_machine.states.monitor import Monitor
 from robot_interface.models.mission import Task, TaskStatus
 from tests.mocks.task import MockTask
 
@@ -13,11 +16,29 @@ from tests.mocks.task import MockTask
         (TaskStatus.Failed, True),
     ],
 )
-def test_task_completed(monitor, mock_status, expected_output):
+def test_task_finished(monitor: Monitor, mock_status, expected_output):
     task: Task = MockTask.drive_to()
     task.status = mock_status
-    task_completed: bool = monitor._task_completed(
+    task_completed: bool = monitor._task_finished(
         task=task,
     )
 
     assert task_completed == expected_output
+
+
+@pytest.mark.parametrize(
+    "mock_status, should_queue_upload",
+    [
+        (TaskStatus.Completed, True),
+        (TaskStatus.Failed, False),
+    ],
+)
+def test_should_only_upload_if_status_is_completed(
+    monitor: Monitor, mock_status, should_queue_upload
+):
+    task: Task = MockTask.take_image_in_coordinate_direction()
+    task.status = mock_status
+    monitor._process_finished_task(task)
+    assert monitor.state_machine.queues.upload_queue.empty() == (
+        not should_queue_upload
+    )


### PR DESCRIPTION
Closes [Failed task caused the state machine to crash](https://github.com/equinor/isar_taurob/issues/81) in isar_taurob
I couldn't find any other states in the state machine that did not have exception handling for method calls to the RobotInterface, so I think this PR should cover that for now.