### PR TITLE
Rename `task.name`to `task.type`

### DIFF
--- a/src/isar/config/predefined_missions/default.json
+++ b/src/isar/config/predefined_missions/default.json
@@ -2,7 +2,7 @@
   "id": 1,
   "tasks": [
     {
-      "name": "drive_to_pose",
+      "type": "drive_to_pose",
       "pose": {
         "position": {
           "x": -2,
@@ -21,7 +21,7 @@
       }
     },
     {
-      "name": "take_image",
+      "type": "take_image",
       "target": {
         "x": 2,
         "y": 2,
@@ -30,7 +30,7 @@
       }
     },
     {
-      "name": "drive_to_pose",
+      "type": "drive_to_pose",
       "pose": {
         "position": {
           "x": -2,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "name": "take_thermal_image",
+      "type": "take_thermal_image",
       "target": {
         "x": 2,
         "y": 2,
@@ -58,7 +58,7 @@
       }
     },
     {
-      "name": "drive_to_pose",
+      "type": "drive_to_pose",
       "pose": {
         "position": {
           "x": 2,

--- a/src/isar/config/predefined_missions/default_turtlebot.json
+++ b/src/isar/config/predefined_missions/default_turtlebot.json
@@ -2,7 +2,7 @@
     "id": 2,
     "tasks": [
         {
-            "name": "drive_to_pose",
+            "type": "drive_to_pose",
             "pose": {
                 "position": {
                     "x": -3.6,
@@ -21,7 +21,7 @@
             }
         },
         {
-            "name": "take_image",
+            "type": "take_image",
             "target": {
                 "x": -4.7,
                 "y": 4.9,
@@ -30,7 +30,7 @@
             }
         },
         {
-            "name": "drive_to_pose",
+            "type": "drive_to_pose",
             "pose": {
                 "position": {
                     "x": 4.7,
@@ -49,7 +49,7 @@
             }
         },
         {
-            "name": "take_image",
+            "type": "take_image",
             "target": {
                 "x": 5.6,
                 "y": 5.2,
@@ -58,7 +58,7 @@
             }
         },
         {
-            "name": "drive_to_pose",
+            "type": "drive_to_pose",
             "pose": {
                 "position": {
                     "x": 0.95,
@@ -77,7 +77,7 @@
             }
         },
         {
-            "name": "take_thermal_image",
+            "type": "take_thermal_image",
             "target": {
                 "x": 1.9,
                 "y": 1.9,

--- a/src/isar/state_machine/states/initiate_task.py
+++ b/src/isar/state_machine/states/initiate_task.py
@@ -72,7 +72,7 @@ class InitiateTask(State):
                 self.state_machine.current_task.status = TaskStatus.Failed
                 self.logger.warning(
                     f"Dependency for task {self.state_machine.current_task_index}: "
-                    f"{self.state_machine.current_task.name}, not fulfilled, "
+                    f"{self.state_machine.current_task.type}, not fulfilled, "
                     "skipping to next task"
                 )
 

--- a/src/robot_interface/models/mission/task.py
+++ b/src/robot_interface/models/mission/task.py
@@ -85,7 +85,7 @@ class DriveToPose(MotionTask):
     """
 
     pose: Pose
-    name: Literal["drive_to_pose"] = "drive_to_pose"
+    type: Literal["drive_to_pose"] = "drive_to_pose"
     depends_on: Optional[List[int]] = None
 
 
@@ -96,7 +96,7 @@ class DockingProcedure(MotionTask):
     """
 
     behavior: Literal["dock, undock"]
-    name: Literal["docking_procedure"] = "docking_procedure"
+    type: Literal["docking_procedure"] = "docking_procedure"
 
 
 @dataclass
@@ -106,7 +106,7 @@ class TakeImage(InspectionTask):
     """
 
     target: Position
-    name: Literal["take_image"] = "take_image"
+    type: Literal["take_image"] = "take_image"
     depends_on: Optional[List[int]] = None
 
 
@@ -117,7 +117,7 @@ class TakeThermalImage(InspectionTask):
     """
 
     target: Position
-    name: Literal["take_thermal_image"] = "take_thermal_image"
+    type: Literal["take_thermal_image"] = "take_thermal_image"
     depends_on: Optional[List[int]] = None
 
 

--- a/tests/integration/turtlebot/config/missions/default.json
+++ b/tests/integration/turtlebot/config/missions/default.json
@@ -2,7 +2,7 @@
     "id": 2,
     "tasks": [
         {
-            "name": "drive_to_pose",
+            "type": "drive_to_pose",
             "pose": {
                 "position": {
                     "x": -3.6,
@@ -21,7 +21,7 @@
             }
         },
         {
-            "name": "take_image",
+            "type": "take_image",
             "target": {
                 "x": -4.7,
                 "y": 4.9,
@@ -30,7 +30,7 @@
             }
         },
         {
-            "name": "drive_to_pose",
+            "type": "drive_to_pose",
             "pose": {
                 "position": {
                     "x": 4.7,
@@ -49,7 +49,7 @@
             }
         },
         {
-            "name": "take_image",
+            "type": "take_image",
             "target": {
                 "x": 5.6,
                 "y": 5.2,
@@ -58,7 +58,7 @@
             }
         },
         {
-            "name": "drive_to_pose",
+            "type": "drive_to_pose",
             "pose": {
                 "position": {
                     "x": 0.95,
@@ -77,7 +77,7 @@
             }
         },
         {
-            "name": "take_thermal_image",
+            "type": "take_thermal_image",
             "target": {
                 "x": 1.9,
                 "y": 1.9,

--- a/tests/isar/services/readers/test_mission_reader.py
+++ b/tests/isar/services/readers/test_mission_reader.py
@@ -75,7 +75,7 @@ def test_thermal_image_task(mission_reader):
 
     assert isinstance(task, TakeThermalImage)
     assert hasattr(task, "target")
-    assert task.name == "take_thermal_image"
+    assert task.type == "take_thermal_image"
     assert hasattr(task, "id")
     assert hasattr(task, "tag_id")
 

--- a/tests/test_data/test_mission_not_working.json
+++ b/tests/test_data/test_mission_not_working.json
@@ -2,7 +2,7 @@
   "id": 1,
   "tasks": [
     {
-      "action_name": "drive_to",
+      "action_type": "drive_to",
       "action_message": {
         "xypsi_pose": {
           "x": -2,
@@ -12,7 +12,7 @@
       }
     },
     {
-      "action_name": "drive_three",
+      "action_type": "drive_three",
       "action_message": {
         "xypsi_pose": {
           "x": -2,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "action_name": "drive_to",
+      "action_type": "drive_to",
       "action_message": {
         "xypsi_pose": {
           "x": 2,
@@ -32,7 +32,7 @@
       }
     },
     {
-      "action_name": "drive_to",
+      "action_type": "drive_to",
       "action_message": {
         "uups": {
           "x": 0,

--- a/tests/test_data/test_mission_working.json
+++ b/tests/test_data/test_mission_working.json
@@ -2,7 +2,7 @@
   "id": 1,
   "tasks": [
     {
-      "name": "drive_to_pose",
+      "type": "drive_to_pose",
       "pose": {
         "position": {
           "x": -2,
@@ -21,7 +21,7 @@
       }
     },
     {
-      "name": "drive_to_pose",
+      "type": "drive_to_pose",
       "pose": {
         "position": {
           "x": -2,
@@ -40,7 +40,7 @@
       }
     },
     {
-      "name": "take_image",
+      "type": "take_image",
       "target": {
         "x": 2,
         "y": 2,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "name": "drive_to_pose",
+      "type": "drive_to_pose",
       "pose": {
         "position": {
           "x": 2,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "name": "take_image",
+      "type": "take_image",
       "target": {
         "x": 2,
         "y": 2,
@@ -80,7 +80,7 @@
       ]
     },
     {
-      "name": "drive_to_pose",
+      "type": "drive_to_pose",
       "pose": {
         "position": {
           "x": 0,

--- a/tests/test_data/test_thermal_image_mission.json
+++ b/tests/test_data/test_thermal_image_mission.json
@@ -2,7 +2,7 @@
   "id": 1,
   "tasks": [
     {
-      "name": "take_thermal_image",
+      "type": "take_thermal_image",
       "target": {
         "x": 2,
         "y": 2,


### PR DESCRIPTION
The previous `task.name` is not a unique name for a task, but a
description of the type of task, for example `take_image`.

Resolves #157 