### PR TITLE
Bug - Printing wrong config & Logging info when warning

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from isar.apis.api import API
 from isar.config.log import setup_logger
 from isar.config.settings import settings
 from isar.models.communication.queues.queues import Queues
-from isar.modules import get_injector_modules
+from isar.modules import get_injector
 from isar.services.service_connections.mqtt.mqtt_client import MqttClient
 from isar.state_machine.state_machine import main
 from isar.storage.storage_interface import StorageInterface
@@ -19,11 +19,7 @@ if __name__ == "__main__":
     setup_logger()
     logger: Logger = logging.getLogger("main")
 
-    injector_modules, module_config_keys = get_injector_modules()
-    injector: Injector = Injector(injector_modules)
-
-    module_config_log = "\n".join(module_config_keys)
-    logger.info(f"Loaded the following module configurations:\n{module_config_log}")
+    injector: Injector = get_injector()
 
     threads: List[Thread] = []
 

--- a/src/isar/config/settings.env
+++ b/src/isar/config/settings.env
@@ -2,7 +2,9 @@ ISAR_ROBOT_PACKAGE = isar_robot
 
 ISAR_MISSION_PLANNER = local
 
-ISAR_STORAGE = '["local"]'
+ISAR_STORAGE_LOCAL = true
+ISAR_STORAGE_BLOB = false
+ISAR_STORAGE_SLIMM = false
 
 ISAR_MQTT_ENABLED = false
 

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -61,11 +61,12 @@ class Settings(BaseSettings):
     MISSION_PLANNER: str = Field(default="local")
 
     # Determines which storage modules are used by ISAR
-    # Comma separated list of modules to use. Each module will be called when storing
-    # results from inspections
-    # Options [local blob slimm]
+    # Multiple storage modules can be chosen
+    # Each module will be called when storing results from inspections
     # Selecting a different storage module than local may require certain access rights
-    STORAGE: List[str] = Field(default=["local"])
+    STORAGE_LOCAL_ENABLED: bool = Field(default=True)
+    STORAGE_BLOB_ENABLED: bool = Field(default=False)
+    STORAGE_SLIMM_ENABLED: bool = Field(default=False)
 
     # Determines whether the MQTT publishing module should be enabled or not
     # The publishing module will attempt to connect to the MQTT broker configured in

--- a/src/isar/state_machine/states/initiate_task.py
+++ b/src/isar/state_machine/states/initiate_task.py
@@ -118,9 +118,8 @@ class InitiateTask(State):
                 break
             else:
                 self.initiate_task_failure_counter += 1
-                self.logger.info(
-                    f"Initiating task failed #: "
-                    f"{str(self.initiate_task_failure_counter)}"
+                self.logger.warning(
+                    f"Initiating task failed #: {str(self.initiate_task_failure_counter)}"
                 )
                 if (
                     self.initiate_task_failure_counter


### PR DESCRIPTION
The printed config did not show which robot package was being used, and also did not include any module names, leaving the user guessing what the default value was.
The logger logged failed connect attempts as info when it should be warning