### PR TITLE
Allow for Python 3.9

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setup(
             "sphinx",
         ]
     },
-    python_requires=">=3.10",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
Suggesting a new minor release after this PR, for other projects to be able to use with Python 3.9.