### PR TITLE
Add modular task selector interface

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
     # rights
     MISSION_PLANNER: str = Field(default="local")
 
+    # Determines which task selector module is used by ISAR
+    # Options: [sequential]
+    TASK_SELECTOR: str = Field(default="sequential")
+
     # Determines which storage modules are used by ISAR
     # Multiple storage modules can be chosen
     # Each module will be called when storing results from inspections

--- a/src/isar/mission_planner/sequential_task_selector.py
+++ b/src/isar/mission_planner/sequential_task_selector.py
@@ -1,0 +1,23 @@
+from typing import Iterator, List
+
+from isar.mission_planner.task_selector_interface import (
+    TaskSelectorInterface,
+    TaskSelectorStop,
+)
+from isar.models.mission import Task
+
+
+class SequentialTaskSelector(TaskSelectorInterface):
+    def __init__(self) -> None:
+        super().__init__()
+        self._iterator: Iterator = None
+
+    def initialize(self, tasks: List[Task]) -> None:
+        super().initialize(tasks=tasks)
+        self._iterator = iter(self.tasks)
+
+    def next_task(self) -> Task:
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            raise TaskSelectorStop

--- a/src/isar/mission_planner/task_selector_interface.py
+++ b/src/isar/mission_planner/task_selector_interface.py
@@ -1,0 +1,31 @@
+from abc import ABCMeta, abstractmethod
+from typing import List
+
+from isar.models.mission import Task
+
+
+class TaskSelectorInterface(metaclass=ABCMeta):
+    def __init__(self) -> None:
+        self.tasks: List[Task] = None
+
+    def initialize(self, tasks: List[Task]) -> None:
+        self.tasks = tasks
+
+    @abstractmethod
+    def next_task(self) -> Task:
+        """
+        Returns
+        -------
+        Task
+            Returns the next task from the list of tasks
+
+        Raises
+        ------
+        TaskSelectorStop
+            If all tasks have been selected, and the task selection process is complete.
+        """
+        pass
+
+
+class TaskSelectorStop(Exception):
+    pass

--- a/src/isar/models/mission/mission.py
+++ b/src/isar/models/mission/mission.py
@@ -107,10 +107,6 @@ class Mission:
     id: Union[UUID, int, str, None] = None
     status: MissionStatus = MissionStatus.NotStarted
     metadata: MissionMetadata = None
-    _iterator: Iterator = None
-
-    def next_task(self) -> Task:
-        return self._iterator.__next__()
 
     def set_unique_id_and_metadata(self) -> None:
         self._set_unique_id()
@@ -131,9 +127,6 @@ class Mission:
 
         if self.metadata is None:
             self.metadata = MissionMetadata(mission_id=self.id)
-
-        if self._iterator is None:
-            self._iterator = iter(self.tasks)
 
     def api_response_dict(self) -> dict:
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,14 @@ from isar.apis.api import API
 from isar.config.keyvault.keyvault_service import Keyvault
 from isar.mission_planner.echo_planner import EchoPlanner
 from isar.mission_planner.local_planner import LocalPlanner
+from isar.mission_planner.task_selector_interface import TaskSelectorInterface
 from isar.models.communication.queues.queues import Queues
 from isar.modules import (
     APIModule,
     LocalPlannerModule,
     QueuesModule,
     RequestHandlerModule,
+    SequentialTaskSelectorModule,
     ServiceModule,
     StateMachineModule,
     UtilitiesModule,
@@ -47,6 +49,7 @@ def injector():
             RequestHandlerModule,
             ServiceModule,
             StateMachineModule,
+            SequentialTaskSelectorModule,
             UtilitiesModule,
         ]
     )
@@ -116,6 +119,7 @@ def state_machine(injector, robot):
         queues=injector.get(Queues),
         robot=robot,
         mqtt_publisher=injector.get(MqttClientInterface),
+        task_selector=injector.get(TaskSelectorInterface),
     )
 
 


### PR DESCRIPTION
Closes #261.

This PR implements a modular interface for task selection per mission. It also replaces the iterative task selection from the Mission class.