### PR TITLE
Feature - receive missions as json

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ follow_imports = normal
 no_strict_optional = True
 no_site_packages = True
 ignore_missing_imports = True
+ignore_missing_imports_per_module = True
 
 [flake8]
 filename =

--- a/src/isar/apis/api.py
+++ b/src/isar/apis/api.py
@@ -93,6 +93,7 @@ class API:
             self.scheduling_controller.start_mission_by_id,
             methods=["POST"],
             dependencies=[authentication_dependency],
+            summary="Start a mission with id='id' from the current mission planner",
             responses={
                 HTTPStatus.OK.value: {
                     "description": "Mission succesfully started",
@@ -117,7 +118,7 @@ class API:
             self.scheduling_controller.start_mission,
             methods=["POST"],
             dependencies=[authentication_dependency],
-            description="Start the mission provided in JSON format",
+            summary="Start the mission provided in JSON format",
             responses={
                 HTTPStatus.OK.value: {
                     "description": "Mission succesfully started",
@@ -142,6 +143,7 @@ class API:
             self.scheduling_controller.stop_mission,
             methods=["POST"],
             dependencies=[authentication_dependency],
+            summary="Stop the current mission",
             responses={
                 HTTPStatus.OK.value: {
                     "description": "Mission succesfully stopped",
@@ -162,6 +164,7 @@ class API:
             self.scheduling_controller.pause_mission,
             methods=["POST"],
             dependencies=[authentication_dependency],
+            summary="Pause the current mission",
             responses={
                 HTTPStatus.OK.value: {
                     "description": "Mission succesfully paused",
@@ -182,6 +185,7 @@ class API:
             self.scheduling_controller.resume_mission,
             methods=["POST"],
             dependencies=[authentication_dependency],
+            summary="Resume the currently paused mission - if any",
             responses={
                 HTTPStatus.OK.value: {
                     "description": "Mission succesfully resumed",
@@ -202,6 +206,7 @@ class API:
             self.scheduling_controller.drive_to,
             methods=["POST"],
             dependencies=[authentication_dependency],
+            summary="Drive to the provided pose",
             responses={
                 HTTPStatus.OK.value: {
                     "description": "Drive to succesfully started",

--- a/src/isar/apis/api.py
+++ b/src/isar/apis/api.py
@@ -112,7 +112,31 @@ class API:
                 },
             },
         )
-
+        router.add_api_route(
+            "/schedule/start-mission",
+            self.scheduling_controller.start_mission,
+            methods=["POST"],
+            dependencies=[authentication_dependency],
+            description="Start the mission provided in JSON format",
+            responses={
+                HTTPStatus.OK.value: {
+                    "description": "Mission succesfully started",
+                    "model": StartMissionResponse,
+                },
+                HTTPStatus.UNPROCESSABLE_ENTITY.value: {
+                    "description": "Invalid body - The JSON is incorrect",
+                },
+                HTTPStatus.CONFLICT.value: {
+                    "description": "Conflict - Invalid command in the current state",
+                },
+                HTTPStatus.REQUEST_TIMEOUT.value: {
+                    "description": "Timeout - Could not contact state machine",
+                },
+                HTTPStatus.INTERNAL_SERVER_ERROR.value: {
+                    "description": "Internal Server Error - Current state of state machine unknown",
+                },
+            },
+        )
         router.add_api_route(
             "/schedule/stop-mission",
             self.scheduling_controller.stop_mission,

--- a/src/isar/apis/api.py
+++ b/src/isar/apis/api.py
@@ -89,8 +89,8 @@ class API:
         authentication_dependency: Security = Security(self.authenticator.get_scheme())
 
         router.add_api_route(
-            "/schedule/start-mission",
-            self.scheduling_controller.start_mission,
+            "/schedule/start-mission/{id}",
+            self.scheduling_controller.start_mission_by_id,
             methods=["POST"],
             dependencies=[authentication_dependency],
             responses={

--- a/src/isar/apis/models/__init__.py
+++ b/src/isar/apis/models/__init__.py
@@ -1,1 +1,1 @@
-from .models import ApiPose, StartMissionResponse
+from .models import InputPose, StartMissionResponse

--- a/src/isar/apis/models/models.py
+++ b/src/isar/apis/models/models.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from alitra import Pose, Position, Orientation, Frame
 
 
@@ -31,7 +31,7 @@ class InputOrientation(BaseModel):
     y: float
     z: float
     w: float
-    frame_name: str
+    frame_name: str = Field(default="robot")
 
     def to_alitra_orientation(self) -> Orientation:
         return Orientation(
@@ -47,7 +47,7 @@ class InputPosition(BaseModel):
     x: float
     y: float
     z: float
-    frame_name: str
+    frame_name: str = Field(default="robot")
 
     def to_alitra_position(self) -> Position:
         return Position(
@@ -61,7 +61,7 @@ class InputPosition(BaseModel):
 class InputPose(BaseModel):
     position: InputPosition
     orientation: InputOrientation
-    frame_name: str
+    frame_name: str = Field(default="robot")
 
     def to_alitra_pose(self) -> Pose:
         return Pose(

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -53,14 +53,12 @@ def to_isar_mission(mission_definition: StartMissionDefinition) -> Mission:
                 for inspection_type in task.inspection_types
             ]
         except (ValueError) as e:
-            raise MissionPlannerError(
-                f"Failed to create task with exception message: '{str(e)}'"
-            )
+            raise MissionPlannerError(f"Failed to create task: {str(e)}")
         isar_task: Task = Task(steps=[drive_step, *inspection_steps], tag_id=tag_id)
         isar_tasks.append(isar_task)
 
     if not isar_tasks:
-        raise MissionPlannerError("Empty mission")
+        raise MissionPlannerError("Mission does not contain any valid tasks")
 
     isar_mission: Mission = Mission(tasks=isar_tasks)
 
@@ -81,6 +79,6 @@ def create_inspection_step(
     elif inspection_type == TakeThermalVideo.get_inspection_type().__name__:
         inspection = TakeThermalVideo(target=target, duration=duration)
     else:
-        raise ValueError(f"No step supported for inspection_type ='{inspection_type}'")
+        raise ValueError(f"Inspection type '{inspection_type}' not supported")
 
     return inspection

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -1,0 +1,125 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from alitra import Pose, Position, Orientation, Frame
+from isar.mission_planner.mission_planner_interface import MissionPlannerError
+
+from isar.models.mission.mission import Mission, Task
+from robot_interface.models.mission.step import (
+    STEPS,
+    DriveToPose,
+    TakeImage,
+    TakeThermalImage,
+    TakeThermalVideo,
+    TakeVideo,
+)
+
+
+class InputOrientation(BaseModel):
+    x: float
+    y: float
+    z: float
+    w: float
+    frame_name: str
+
+    def to_alitra_orientation(self) -> Orientation:
+        return Orientation(
+            x=self.x,
+            y=self.y,
+            z=self.z,
+            w=self.w,
+            frame=Frame(self.frame_name),
+        )
+
+
+class InputPosition(BaseModel):
+    x: float
+    y: float
+    z: float
+    frame_name: str
+
+    def to_alitra_position(self) -> Position:
+        return Position(
+            x=self.x,
+            y=self.y,
+            z=self.z,
+            frame=Frame(self.frame_name),
+        )
+
+
+class InputPose(BaseModel):
+    orientation: InputOrientation
+    position: InputPosition
+    frame_name: str
+
+    def to_alitra_pose(self) -> Pose:
+        return Pose(
+            position=self.position.to_alitra_position(),
+            orientation=self.orientation.to_alitra_orientation(),
+            frame=Frame(self.frame_name),
+        )
+
+
+# We need to specify our own position/orientation/pose classes that do not contain the "Frame" class
+# because of an bug in generating the OpenAPI specification:
+# https://github.com/tiangolo/fastapi/issues/1505
+# This does not happen if all the classes are 'BaseModel' classes, but the alitra models are 'dataclasses',
+# hence the conversion being done.
+class StartMissionTaskDefinition(BaseModel):
+    pose: InputPose
+    tag: Optional[str]
+    inspection_target: InputPosition = Field(alias="InspectionTarget")
+    sensors_types: List[str] = Field(alias="SensorTypes")
+    video_duration: Optional[float] = Field(default=10)
+
+
+class StartMissionDefinition(BaseModel):
+    tasks: List[StartMissionTaskDefinition]
+
+
+def to_isar_mission(mission_definition: StartMissionDefinition) -> Mission:
+    isar_tasks: List[Task] = []
+
+    for task in mission_definition.tasks:
+        try:
+            tag_id: Optional[str] = task.tag
+            drive_step: DriveToPose = DriveToPose(pose=task.pose.to_alitra_pose())
+            inspection_steps: List[STEPS] = [
+                create_inspection_step(
+                    sensor_type=sensor,
+                    duration=task.video_duration,
+                    target=task.inspection_target,
+                )
+                for sensor in task.sensors_types
+            ]
+        except (ValueError) as e:
+            raise MissionPlannerError(
+                f"Failed to create task with exception message: '{str(e)}'"
+            )
+        isar_task: Task = Task(steps=[drive_step, *inspection_steps], tag_id=tag_id)
+        isar_tasks.append(isar_task)
+
+    if not isar_tasks:
+        raise MissionPlannerError("Empty mission")
+
+    isar_mission: Mission = Mission(tasks=isar_tasks)
+
+    return isar_mission
+
+
+def create_inspection_step(
+    sensor_type: str, duration: float, target: Position
+) -> STEPS:
+    inspection: STEPS
+
+    if sensor_type == TakeImage.type:
+        inspection = TakeImage(target=target)
+    elif sensor_type == TakeVideo.type:
+        inspection = TakeVideo(target=target, duration=duration)
+    elif sensor_type == TakeThermalImage.type:
+        inspection = TakeThermalImage(target=target)
+    elif sensor_type == TakeThermalVideo.type:
+        inspection = TakeThermalVideo(target=target, duration=duration)
+    else:
+        raise ValueError(f"No step supported for sensor_type {sensor_type}")
+
+    return inspection

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional
-from alitra import Pose, Position, Orientation, Frame
+from alitra import Position
+from isar.apis.models.models import InputPose, InputPosition
 from isar.mission_planner.mission_planner_interface import MissionPlannerError
 
 from isar.models.mission.mission import Mission, Task
@@ -14,56 +15,6 @@ from robot_interface.models.mission.step import (
 )
 
 
-class InputOrientation(BaseModel):
-    x: float
-    y: float
-    z: float
-    w: float
-    frame_name: str
-
-    def to_alitra_orientation(self) -> Orientation:
-        return Orientation(
-            x=self.x,
-            y=self.y,
-            z=self.z,
-            w=self.w,
-            frame=Frame(self.frame_name),
-        )
-
-
-class InputPosition(BaseModel):
-    x: float
-    y: float
-    z: float
-    frame_name: str
-
-    def to_alitra_position(self) -> Position:
-        return Position(
-            x=self.x,
-            y=self.y,
-            z=self.z,
-            frame=Frame(self.frame_name),
-        )
-
-
-class InputPose(BaseModel):
-    orientation: InputOrientation
-    position: InputPosition
-    frame_name: str
-
-    def to_alitra_pose(self) -> Pose:
-        return Pose(
-            position=self.position.to_alitra_position(),
-            orientation=self.orientation.to_alitra_orientation(),
-            frame=Frame(self.frame_name),
-        )
-
-
-# We need to specify our own position/orientation/pose classes that do not contain the "Frame" class
-# because of an bug in generating the OpenAPI specification:
-# https://github.com/tiangolo/fastapi/issues/1505
-# This does not happen if all the classes are 'BaseModel' classes, but the alitra models are 'dataclasses',
-# hence the conversion being done.
 class StartMissionTaskDefinition(BaseModel):
     pose: InputPose
     tag: Optional[str]

--- a/src/isar/apis/schedule/scheduling_controller.py
+++ b/src/isar/apis/schedule/scheduling_controller.py
@@ -10,6 +10,10 @@ from injector import inject
 from requests import HTTPError
 
 from isar.apis.models import ApiPose, StartMissionResponse
+from isar.apis.models.start_mission_definition import (
+    StartMissionDefinition,
+    to_isar_mission,
+)
 from isar.config.settings import robot_settings, settings
 from isar.mission_planner.mission_planner_interface import (
     MissionPlannerError,
@@ -85,6 +89,127 @@ class SchedulingController:
             self.logger.error(e)
             response.status_code = e.response.status_code
             raise
+        except MissionPlannerError as e:
+            self.logger.error(e)
+            response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
+            return
+
+        robot_capable: bool
+        missing_functions: List[str]
+        (robot_capable, missing_functions) = is_robot_capable_of_mission(
+            mission=mission, robot_capabilities=robot_settings.CAPABILITIES
+        )
+        if not robot_capable:
+            errorMsg = (
+                "Bad Request - Robot is not capable of performing mission. Missing functionalities: "
+                + str(missing_functions)
+            )
+            self.logger.error(errorMsg)
+            response.status_code = HTTPStatus.BAD_REQUEST.value
+            return errorMsg
+
+        initial_pose_alitra: Optional[Pose]
+        if initial_pose:
+            initial_pose_alitra = Pose(
+                position=Position(
+                    x=initial_pose.x,
+                    y=initial_pose.y,
+                    z=initial_pose.z,
+                    frame=Frame("asset"),
+                ),
+                orientation=Orientation.from_euler_array(
+                    euler=np.array(
+                        [initial_pose.roll, initial_pose.pitch, initial_pose.yaw]
+                    ),
+                    frame=Frame("asset"),
+                ),
+                frame=Frame("asset"),
+            )
+        else:
+            initial_pose_alitra = None
+
+        self.logger.info(f"Starting mission: {mission.id}")
+
+        if return_pose:
+            pose: Pose = Pose(
+                position=Position(
+                    x=return_pose.x,
+                    y=return_pose.y,
+                    z=return_pose.z,
+                    frame=Frame("asset"),
+                ),
+                orientation=Orientation.from_euler_array(
+                    np.array([return_pose.roll, return_pose.pitch, return_pose.yaw]),
+                    Frame("asset"),
+                ),
+                frame=Frame("asset"),
+            )
+            step: DriveToPose = DriveToPose(pose=pose)
+            mission.tasks.append(Task(steps=[step]))
+        try:
+            self.scheduling_utilities.start_mission(
+                mission=mission, initial_pose=initial_pose_alitra
+            )
+            self.logger.info("OK - Mission successfully started")
+        except QueueTimeoutError:
+            errorMsg = "Timeout - Failed to start mission"
+            self.logger.error(errorMsg)
+            response.status_code = HTTPStatus.REQUEST_TIMEOUT.value
+            return errorMsg
+        return StartMissionResponse(**mission.api_response_dict())
+
+    def start_mission(
+        self,
+        response: Response,
+        mission_definition: StartMissionDefinition = Body(
+            default=None,
+            embed=True,
+            title="Mission Definition",
+            description="Description of the mission in json format",
+        ),
+        initial_pose: Optional[ApiPose] = Body(
+            default=None,
+            description="The starting point of the mission. Used for initial localization of robot",
+            embed=True,
+        ),
+        return_pose: Optional[ApiPose] = Body(
+            default=None,
+            description="End pose of the mission. The robot return to the specified pose after finsihing all inspections",
+            embed=True,
+        ),
+    ):
+        self.logger.info("Received request to start new mission")
+
+        if not mission_definition:
+            errorMsg: str = (
+                "Unprocessable entity - 'mission_definition' empty or invalid"
+            )
+            self.logger.error(errorMsg)
+            response.status_code = HTTPStatus.UNPROCESSABLE_ENTITY.value
+            return errorMsg
+
+        try:
+            state: States = self.scheduling_utilities.get_state()
+        except Empty:
+            errorMsg = "Internal Server Error - Current state of state machine unknown"
+            self.logger.error(errorMsg)
+            response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
+            return errorMsg
+
+        if state in [
+            States.Initialize,
+            States.InitiateStep,
+            States.StopStep,
+            States.Monitor,
+            States.Paused,
+        ]:
+            errorMsg = "Conflict - Mission already in progress"
+            self.logger.warning(errorMsg)
+            response.status_code = HTTPStatus.CONFLICT.value
+            return errorMsg
+
+        try:
+            mission: Mission = to_isar_mission(mission_definition)
         except MissionPlannerError as e:
             self.logger.error(e)
             response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value

--- a/src/isar/apis/schedule/scheduling_controller.py
+++ b/src/isar/apis/schedule/scheduling_controller.py
@@ -211,9 +211,10 @@ class SchedulingController:
         try:
             mission: Mission = to_isar_mission(mission_definition)
         except MissionPlannerError as e:
-            self.logger.error(e)
-            response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
-            return
+            errorMsg = f"Bad Request - Cannot create ISAR mission: {e}"
+            self.logger.warning(errorMsg)
+            response.status_code = HTTPStatus.BAD_REQUEST.value
+            return errorMsg
 
         robot_capable: bool
         missing_functions: List[str]

--- a/src/isar/apis/schedule/scheduling_controller.py
+++ b/src/isar/apis/schedule/scheduling_controller.py
@@ -1,11 +1,11 @@
 import logging
 from http import HTTPStatus
 from queue import Empty
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import numpy as np
 from alitra import Frame, Orientation, Pose, Position
-from fastapi import Body, Query, Response
+from fastapi import Body, Path, Query, Response
 from injector import inject
 from requests import HTTPError
 
@@ -36,12 +36,12 @@ class SchedulingController:
         self.scheduling_utilities: SchedulingUtilities = scheduling_utilities
         self.queue_timeout: int = queue_timeout
 
-    def start_mission(
+    def start_mission_by_id(
         self,
         response: Response,
-        mission_id: int = Query(
+        mission_id: int = Path(
             ...,
-            alias="ID",
+            alias="id",
             title="Mission ID",
             description="ID-number for predefined mission",
         ),
@@ -56,7 +56,7 @@ class SchedulingController:
             embed=True,
         ),
     ):
-        self.logger.info("Received request to start new mission")
+        self.logger.info(f"Received request to start mission with id {mission_id}")
         try:
             state: States = self.scheduling_utilities.get_state()
         except Empty:

--- a/src/isar/models/mission/mission.py
+++ b/src/isar/models/mission/mission.py
@@ -6,8 +6,8 @@ from uuid import UUID, uuid4
 from isar.config.settings import settings
 from isar.models.mission_metadata.mission_metadata import MissionMetadata
 from robot_interface.models.mission import (
-    STEPS,
     InspectionStep,
+    STEPS,
     MotionStep,
     Step,
     StepStatus,

--- a/src/robot_interface/models/mission/step.py
+++ b/src/robot_interface/models/mission/step.py
@@ -63,6 +63,7 @@ class InspectionStep(Step):
 
     inspections: List[Inspection] = field(default_factory=list, init=False)
     tag_id: Optional[str] = field(default=None, init=False)
+    type = "inspection_type"
 
     @staticmethod
     def get_inspection_type() -> Type[Inspection]:


### PR DESCRIPTION
Closes #293 
Related to https://github.com/equinor/flotilla/issues/271

Replacing the "ApiPose" class with the new "InputPose" class was done for consistency, as we now only take quaternions as input, and a 'pose' is always defined the same way for the users of our API endpoints.
Whether or not we should accept euler angles instead is up for discussion, I guess.