### PR TITLE
Add action to post repository dispatch event

### DIFF
--- a/.github/workflows/repository_dispatch_on_merge.yml
+++ b/.github/workflows/repository_dispatch_on_merge.yml
@@ -1,0 +1,22 @@
+name: Dispatch to repo
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+jobs:
+  dispatch:
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ["equinor/robotics-deployment"]
+    steps:
+      - name: Push to repo
+        uses: peter-evans/repository-dispatch@v2.0.0
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ matrix.repo }}
+          event-type: update
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "module": "isar", "branch": "main"}'


### PR DESCRIPTION
This action will post a repository dispatch event on every merge to main which triggers a multi-repository build.