### PR TITLE
Configure pipeline to not cancel jobs on fail

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
 


### PR DESCRIPTION
Previously the pipeline cancelled all python version jobs if one version failed. With this modification, one can see exactly which version fails. 