### PR TITLE
Retry on failed attempt not on queue loop

### DIFF
--- a/src/isar/state_machine/states/stop_step.py
+++ b/src/isar/state_machine/states/stop_step.py
@@ -45,14 +45,16 @@ class StopStep(State):
             try:
                 self.stop_thread.get_output()
             except ThreadedRequestNotFinishedError:
+                time.sleep(self.state_machine.sleep_time)
+                continue
+
+            except RobotException:
                 if self.handle_stop_fail(
                     retry_limit=self.state_machine.stop_robot_attempts_limit
                 ):
                     transition = self.state_machine.mission_stopped
                     break
-                continue
 
-            except RobotException:
                 self.logger.warning("Failed to stop robot. Retrying.")
                 self.stop_thread = None
                 continue
@@ -68,7 +70,8 @@ class StopStep(State):
         self._count_number_retries += 1
         if self._count_number_retries > retry_limit:
             self.logger.warning(
-                "Could not communicate request: Reached limit for stop attemps. Cancelled mission and transitioned to idle."
+                "Could not communicate request: Reached limit for stop attempts. "
+                "Cancelled mission and transitioned to idle."
             )
             return True
         time.sleep(self.state_machine.sleep_time)


### PR DESCRIPTION
The `handle_stop_fail` function should not be called on every thread not finished error as this is basically the while loop but rather if we fail to stop. 