### PR TITLE
Publish correct task status on failed initiate

### DIFF
--- a/src/isar/state_machine/state_machine.py
+++ b/src/isar/state_machine/state_machine.py
@@ -301,8 +301,10 @@ class StateMachine(object):
 
     def _initiate_step_failed(self) -> None:
         self.current_step.status = StepStatus.Failed
+        self.current_task.status = TaskStatus.Failed
         self.current_mission.status = MissionStatus.Failed
         self.publish_step_status()
+        self.publish_task_status()
         self._finalize()
 
     def _step_infeasible(self) -> None:


### PR DESCRIPTION
The task status was not reported before and thus ended up in Flotilla as `in_progress` which is not correct. Now both step, task and mission status should be correctly published as failed. 