### PR TITLE
Add send inspection path after upload

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -232,6 +232,7 @@ class Settings(BaseSettings):
     TOPIC_ISAR_MISSION: str = Field(default="mission")
     TOPIC_ISAR_TASK: str = Field(default="task")
     TOPIC_ISAR_STEP: str = Field(default="step")
+    TOPIC_ISAR_INSPECTION_RESULT = Field(default="inspection_result")
     TOPIC_ISAR_ROBOT_STATUS: str = Field(default="robot_status")
     TOPIC_ISAR_ROBOT_INFO: str = Field(default="robot_info")
 
@@ -282,6 +283,7 @@ class Settings(BaseSettings):
         "TOPIC_ISAR_STEP",
         "TOPIC_ISAR_ROBOT_STATUS",
         "TOPIC_ISAR_ROBOT_INFO",
+        "TOPIC_ISAR_INSPECTION_RESULT",
         pre=True,
         always=True,
     )

--- a/src/isar/storage/local_storage.py
+++ b/src/isar/storage/local_storage.py
@@ -13,7 +13,7 @@ class LocalStorage(StorageInterface):
         self.root_folder: Path = Path(settings.LOCAL_STORAGE_PATH)
         self.logger = logging.getLogger("uploader")
 
-    def store(self, inspection: Inspection, metadata: MissionMetadata) -> None:
+    def store(self, inspection: Inspection, metadata: MissionMetadata) -> str:
         local_path, local_metadata_path = construct_local_paths(
             inspection=inspection, metadata=metadata
         )
@@ -43,3 +43,4 @@ class LocalStorage(StorageInterface):
                 "An unexpected error occurred while writing to local storage"
             )
             raise StorageException from e
+        return str(absolute_path)

--- a/src/isar/storage/storage_interface.py
+++ b/src/isar/storage/storage_interface.py
@@ -6,7 +6,7 @@ from robot_interface.models.inspection.inspection import Inspection
 
 class StorageInterface(metaclass=ABCMeta):
     @abstractmethod
-    def store(self, inspection: Inspection, metadata: MissionMetadata):
+    def store(self, inspection: Inspection, metadata: MissionMetadata) -> str:
         """
         Parameters
         ----------
@@ -14,6 +14,11 @@ class StorageInterface(metaclass=ABCMeta):
             Metadata for the mission the inspection is a part of.
         inspection : Inspection
             The inspection object to be stored.
+
+        Returns
+        ----------
+        String
+            Path of the saved inspection
 
         Raises
         ----------


### PR DESCRIPTION
closes #430 
From Slim upload, it sends image guid.
From Blob upload, it sends etag.
From local it sends the file path. 
The paths is sent with "TOPIC_ISAR_INSPECTION_RESULT"