### PR TITLE
Change type of analysis from list to str

### DIFF
--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -30,7 +30,7 @@ class InspectionTypes(str, Enum):
 class StartMissionInspectionDefinition(BaseModel):
     type: InspectionTypes = Field(default=InspectionTypes.image)
     inspection_target: InputPosition
-    analysis_types: Optional[List]
+    analysis_types: Optional[str]
     duration: Optional[float]
     metadata: Optional[dict]
     id: Optional[str]
@@ -108,7 +108,7 @@ def create_inspection_step(
     inspection_type: InspectionTypes,
     duration: float,
     target: Position,
-    analysis: Optional[List],
+    analysis: Optional[str],
     tag_id: Optional[str],
     metadata: Optional[dict],
     id: Optional[str],

--- a/src/isar/config/predefined_mission_definition/default_mission.json
+++ b/src/isar/config/predefined_mission_definition/default_mission.json
@@ -28,10 +28,7 @@
                             "z": 0,
                             "frame_name": "robot"
                         },
-                        "analysis_types": [
-                            "CarSeal",
-                            "Rust"
-                        ],
+                        "analysis_types": "CarSeal, Rust",
                         "metadata": {
                             "zoom": "2x"
                         }
@@ -44,9 +41,8 @@
                             "z": 0,
                             "frame_name": "robot"
                         },
-                        "analysis_types": [
-                            "GasDetection"
-                        ],
+                        "analysis_types": "GasDetection"
+                        ,
                         "duration": 10
                     }
                 ]
@@ -77,10 +73,7 @@
                             "z": 0,
                             "frame_name": "robot"
                         },
-                        "analysis_types": [
-                            "ColdSpot",
-                            "HotSpot"
-                        ]
+                        "analysis_types": "ColdSpot,HotSpot"
                     },
                     {
                         "type": "Video",

--- a/src/isar/config/predefined_mission_definition/default_turtlebot.json
+++ b/src/isar/config/predefined_mission_definition/default_turtlebot.json
@@ -28,10 +28,8 @@
                             "z": 0,
                             "frame": "robot"
                         },
-                        "analysis_types": [
-                            "CarSeal",
-                            "Rust"
-                        ],
+                        "analysis_types": "CarSeal, Rust"
+                        ,
                         "metadata": {
                             "zoom": "2x"
                         }
@@ -44,9 +42,7 @@
                             "z": 0,
                             "frame": "robot"
                         },
-                        "analysis_types": [
-                            "GasDetection"
-                        ]
+                        "analysis_types": "GasDetection"
                     }
                 ]
             },
@@ -77,10 +73,8 @@
                             "z": 0,
                             "frame": "robot"
                         },
-                        "analysis_types": [
-                            "ColdSpot",
-                            "HotSpot"
-                        ]
+                        "analysis_types": "ColdSpot, HotSpot"
+                        
                     }
                 ]
             },
@@ -111,10 +105,7 @@
                             "z": 0,
                             "frame": "robot"
                         },
-                        "analysis_types": [
-                            "ColdSpot",
-                            "HotSpot"
-                        ]
+                        "analysis_types": "ColdSpot, HotSpot"
                     },
                     {
                         "type": "ThermalImage",
@@ -124,10 +115,7 @@
                             "z": 0,
                             "frame": "robot"
                         },
-                        "analysis_types": [
-                            "ColdSpot",
-                            "HotSpot"
-                        ]
+                        "analysis_types": "ColdSpot, HotSpot"
                     }
                 ]
             }

--- a/src/isar/storage/slimm_storage.py
+++ b/src/isar/storage/slimm_storage.py
@@ -124,11 +124,13 @@ class SlimmStorage(StorageInterface):
                 "ImageMetadata.CameraOrientation2": str(array_of_orientation[1]),
                 "ImageMetadata.CameraOrientation3": str(array_of_orientation[2]),
                 "ImageMetadata.CameraOrientation4": str(array_of_orientation[3]),
-                "ImageMetadata.AnalysisMethods": str(inspection.metadata.analysis),
+                "ImageMetadata.AnalysisMethods": inspection.metadata.analysis
+                if inspection.metadata.analysis
+                else "N/A",
                 "ImageMetadata.Description": str(inspection.metadata.additional),
                 "ImageMetadata.FunctionalLocation": inspection.metadata.tag_id  # noqa: E501
                 if inspection.metadata.tag_id
-                else "NA",
+                else "N/A",
                 "Filename": filename,
                 "AttachedFile": (filename, inspection.data),
             }
@@ -166,11 +168,13 @@ class SlimmStorage(StorageInterface):
                 "VideoMetadata.CameraOrientation2": str(array_of_orientation[1]),
                 "VideoMetadata.CameraOrientation3": str(array_of_orientation[2]),
                 "VideoMetadata.CameraOrientation4": str(array_of_orientation[3]),
-                "VideoMetadata.AnalysisMethods": str(inspection.metadata.analysis),
+                "VideoMetadata.AnalysisMethods": inspection.metadata.analysis
+                if inspection.metadata.analysis
+                else "N/A",
                 "VideoMetadata.Description": str(inspection.metadata.additional),
                 "VideoMetadata.FunctionalLocation": inspection.metadata.tag_id  # noqa: E501
                 if inspection.metadata.tag_id
-                else "NA",
+                else "N/A",
                 "Filename": filename,
                 "AttachedFile": (filename, inspection.data),
             }

--- a/src/robot_interface/models/inspection/inspection.py
+++ b/src/robot_interface/models/inspection/inspection.py
@@ -13,7 +13,7 @@ class InspectionMetadata(ABC):
     start_time: datetime
     pose: Pose
     file_type: str
-    analysis: Optional[List] = field(default_factory=list, init=False)
+    analysis: Optional[str] = field(default=None, init=False)
     tag_id: Optional[str] = field(default=None, init=False)
     additional: Optional[dict] = field(default_factory=dict, init=False)
 

--- a/src/robot_interface/models/mission/step.py
+++ b/src/robot_interface/models/mission/step.py
@@ -64,7 +64,7 @@ class InspectionStep(Step):
     inspections: List[Inspection] = field(default_factory=list, init=False)
     tag_id: Optional[str] = field(default=None, init=False)
     type = "inspection_type"
-    analysis: Optional[List] = field(default_factory=list, init=False)
+    analysis: Optional[str] = field(default=None, init=False)
     metadata: Optional[dict] = field(default_factory=dict, init=False)
 
     @staticmethod

--- a/tests/isar/mission/test_mission.py
+++ b/tests/isar/mission/test_mission.py
@@ -159,7 +159,7 @@ def test_mission_definition() -> None:
             loaded_step: STEPS = loaded_task.steps[i_step]
             expected_step: STEPS = expected_task.steps[i_step]
 
-            ignore_attributes = set(("id", "status", "tag_id"))
+            ignore_attributes = set(("id", "status", "tag_id", "analysis"))
             loaded_attributes = set(loaded_step.__dict__.keys()) - ignore_attributes
             expected_attributes = set(expected_step.__dict__.keys()) - ignore_attributes
 

--- a/tests/mocks/mission_definition.py
+++ b/tests/mocks/mission_definition.py
@@ -43,19 +43,19 @@ class MockMissionDefinition:
     mock_start_mission_inspection_definition = StartMissionInspectionDefinition(
         type=InspectionTypes.image,
         inspection_target=mock_input_target_position,
-        analysis_types=["analysis"],
+        analysis_types="analysis",
     )
     mock_start_mission_inspection_definition_id_123 = StartMissionInspectionDefinition(
         type=InspectionTypes.image,
         inspection_target=mock_input_target_position,
-        analysis_types=["analysis"],
+        analysis_types="analysis",
         id="123",
     )
     mock_start_mission_inspection_definition_id_123456 = (
         StartMissionInspectionDefinition(
             type=InspectionTypes.image,
             inspection_target=mock_input_target_position,
-            analysis_types=["analysis"],
+            analysis_types="analysis",
             id="123456",
         )
     )


### PR DESCRIPTION
The analysis type is string in flotilla and SLIMM, so it should be the same in ISAR