### PR TITLE
Instantiate Mock members by function

### DIFF
--- a/tests/isar/services/readers/test_base_reader.py
+++ b/tests/isar/services/readers/test_base_reader.py
@@ -17,8 +17,8 @@ class TestBaseReader:
         "dataclass_dict, expected_dataclass",
         [
             (asdict(MockMissionDefinition.default_mission), Mission),
-            (asdict(MockStep.drive_to), Step),
-            (asdict(MockStep.take_image_in_coordinate_direction), Step),
+            (asdict(MockStep.drive_to()), Step),
+            (asdict(MockStep.take_image_in_coordinate_direction()), Step),
             (asdict(MockPose.default_pose), Pose),
         ],
     )

--- a/tests/isar/services/readers/test_base_reader.py
+++ b/tests/isar/services/readers/test_base_reader.py
@@ -19,7 +19,7 @@ class TestBaseReader:
             (asdict(MockMissionDefinition.default_mission), Mission),
             (asdict(MockStep.drive_to()), Step),
             (asdict(MockStep.take_image_in_coordinate_direction()), Step),
-            (asdict(MockPose.default_pose), Pose),
+            (asdict(MockPose.default_pose()), Pose),
         ],
     )
     def test_dict_to_dataclass(self, dataclass_dict: dict, expected_dataclass: Any):

--- a/tests/isar/state_machine/states/test_monitor.py
+++ b/tests/isar/state_machine/states/test_monitor.py
@@ -17,7 +17,7 @@ from tests.mocks.step import MockStep
     ],
 )
 def test_step_finished(monitor: Monitor, mock_status, expected_output):
-    step: Step = MockStep.drive_to
+    step: Step = MockStep.drive_to()
     step.status = mock_status
     step_completed: bool = monitor._step_finished(
         step=step,
@@ -36,7 +36,7 @@ def test_step_finished(monitor: Monitor, mock_status, expected_output):
 def test_should_only_upload_if_status_is_completed(
     monitor: Monitor, mock_status, should_queue_upload
 ):
-    step: TakeImage = MockStep.take_image_in_coordinate_direction
+    step: TakeImage = MockStep.take_image_in_coordinate_direction()
     step.status = mock_status
     task: Task = Task(steps=[step])
     mission: Mission = Mission(tasks=[task])

--- a/tests/isar/state_machine/test_state_machine.py
+++ b/tests/isar/state_machine/test_state_machine.py
@@ -91,8 +91,8 @@ empty_mission: Mission = Mission([], None)
 
 
 def test_state_machine_transitions(injector, state_machine_thread) -> None:
-    step_1: Step = DriveToPose(pose=MockPose.default_pose)
-    step_2: Step = TakeImage(target=MockPose.default_pose.position)
+    step_1: Step = DriveToPose(pose=MockPose.default_pose())
+    step_2: Step = TakeImage(target=MockPose.default_pose().position)
     mission: Mission = Mission(tasks=[Task(steps=[step_1, step_2])])  # type: ignore
 
     scheduling_utilities: SchedulingUtilities = injector.get(SchedulingUtilities)
@@ -121,8 +121,8 @@ def test_state_machine_transitions_when_running_full_mission(
 ) -> None:
     state_machine_thread.state_machine.stepwise_mission = False
 
-    step_1: Step = DriveToPose(pose=MockPose.default_pose)
-    step_2: Step = TakeImage(target=MockPose.default_pose.position)
+    step_1: Step = DriveToPose(pose=MockPose.default_pose())
+    step_2: Step = TakeImage(target=MockPose.default_pose().position)
     mission: Mission = Mission(tasks=[Task(steps=[step_1, step_2])])  # type: ignore
 
     scheduling_utilities: SchedulingUtilities = injector.get(SchedulingUtilities)
@@ -147,7 +147,7 @@ def test_state_machine_transitions_when_running_full_mission(
 def test_state_machine_failed_dependency(
     injector, state_machine_thread, mocker
 ) -> None:
-    drive_to_step: Step = DriveToPose(pose=MockPose.default_pose)
+    drive_to_step: Step = DriveToPose(pose=MockPose.default_pose())
     inspection_step: Step = MockStep.take_image_in_coordinate_direction()
     mission: Mission = Mission(tasks=[Task(steps=[drive_to_step, inspection_step])])  # type: ignore
 

--- a/tests/isar/state_machine/test_state_machine.py
+++ b/tests/isar/state_machine/test_state_machine.py
@@ -148,7 +148,7 @@ def test_state_machine_failed_dependency(
     injector, state_machine_thread, mocker
 ) -> None:
     drive_to_step: Step = DriveToPose(pose=MockPose.default_pose)
-    inspection_step: Step = MockStep.take_image_in_coordinate_direction
+    inspection_step: Step = MockStep.take_image_in_coordinate_direction()
     mission: Mission = Mission(tasks=[Task(steps=[drive_to_step, inspection_step])])  # type: ignore
 
     mocker.patch.object(MockRobot, "step_status", return_value=StepStatus.Failed)
@@ -177,7 +177,7 @@ def test_state_machine_with_successful_collection(
 ) -> None:
     storage_mock: StorageInterface = injector.get(List[StorageInterface])[0]
 
-    step: TakeImage = MockStep.take_image_in_coordinate_direction
+    step: TakeImage = MockStep.take_image_in_coordinate_direction()
     mission: Mission = Mission(tasks=[Task(steps=[step])])
     scheduling_utilities: SchedulingUtilities = injector.get(SchedulingUtilities)
 
@@ -207,7 +207,7 @@ def test_state_machine_with_unsuccessful_collection(
 
     mocker.patch.object(MockRobot, "get_inspections", return_value=[])
 
-    step: TakeImage = MockStep.take_image_in_coordinate_direction
+    step: TakeImage = MockStep.take_image_in_coordinate_direction()
     mission: Mission = Mission(tasks=[Task(steps=[step])])
     scheduling_utilities: SchedulingUtilities = injector.get(SchedulingUtilities)
 
@@ -236,7 +236,7 @@ def test_state_machine_with_successful_mission_stop(
     state_machine_thread: StateMachineThread,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    step: TakeImage = MockStep.take_image_in_coordinate_direction
+    step: TakeImage = MockStep.take_image_in_coordinate_direction()
     mission: Mission = Mission(tasks=[Task(steps=[step])])
 
     scheduling_utilities: SchedulingUtilities = injector.get(SchedulingUtilities)
@@ -266,7 +266,7 @@ def test_state_machine_with_unsuccessful_mission_stop(
     state_machine_thread: StateMachineThread,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    step: TakeImage = MockStep.take_image_in_coordinate_direction
+    step: TakeImage = MockStep.take_image_in_coordinate_direction()
     mission: Mission = Mission(tasks=[Task(steps=[step])])
 
     scheduling_utilities: SchedulingUtilities = injector.get(SchedulingUtilities)

--- a/tests/mocks/mission_definition.py
+++ b/tests/mocks/mission_definition.py
@@ -30,12 +30,15 @@ class MockMissionDefinition:
         id="default_mission",
         tasks=[
             Task(
-                steps=[MockStep.take_image_in_coordinate_direction, MockStep.drive_to]
+                steps=[
+                    MockStep.take_image_in_coordinate_direction(),
+                    MockStep.drive_to(),
+                ]
             ),
             Task(
                 steps=[
-                    MockStep.take_image_in_coordinate_direction,
-                    MockStep.take_image_in_coordinate_direction,
+                    MockStep.take_image_in_coordinate_direction(),
+                    MockStep.take_image_in_coordinate_direction(),
                 ]
             ),
         ],

--- a/tests/mocks/pose.py
+++ b/tests/mocks/pose.py
@@ -2,8 +2,10 @@ from alitra import Frame, Orientation, Pose, Position
 
 
 class MockPose:
-    default_pose = Pose(
-        position=Position(x=0, y=0, z=0, frame=Frame("robot")),
-        orientation=Orientation(x=0, y=0, z=0, w=1, frame=Frame("robot")),
-        frame=Frame("robot"),
-    )
+    @staticmethod
+    def default_pose():
+        return Pose(
+            position=Position(x=0, y=0, z=0, frame=Frame("robot")),
+            orientation=Orientation(x=0, y=0, z=0, w=1, frame=Frame("robot")),
+            frame=Frame("robot"),
+        )

--- a/tests/mocks/step.py
+++ b/tests/mocks/step.py
@@ -5,7 +5,10 @@ from tests.mocks.pose import MockPose
 
 
 class MockStep:
-    drive_to = DriveToPose(pose=MockPose.default_pose)
-    take_image_in_coordinate_direction = TakeImage(
-        target=Position(x=1, y=1, z=1, frame=Frame("robot"))
-    )
+    @staticmethod
+    def drive_to() -> DriveToPose:
+        return DriveToPose(pose=MockPose.default_pose)
+
+    @staticmethod
+    def take_image_in_coordinate_direction() -> TakeImage:
+        return TakeImage(target=Position(x=1, y=1, z=1, frame=Frame("robot")))

--- a/tests/mocks/step.py
+++ b/tests/mocks/step.py
@@ -7,7 +7,7 @@ from tests.mocks.pose import MockPose
 class MockStep:
     @staticmethod
     def drive_to() -> DriveToPose:
-        return DriveToPose(pose=MockPose.default_pose)
+        return DriveToPose(pose=MockPose.default_pose())
 
     @staticmethod
     def take_image_in_coordinate_direction() -> TakeImage:


### PR DESCRIPTION
Fixes bug in state machine tests due to class instance member being mutated across different tests.

Resolves #516 