### PR TITLE
Adjust inspection_result message

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -144,9 +144,7 @@ class Settings(BaseSettings):
     UPLOAD_INSPECTIONS_ASYNC: bool = Field(default=False)
 
     # URL to storage account for Azure Blob Storage
-    BLOB_STORAGE_ACCOUNT_URL: str = Field(
-        default="https://eqrobotdevstorage.blob.core.windows.net"
-    )
+    BLOB_STORAGE_ACCOUNT: str = Field(default="eqrobotdevstorage")
 
     # Name of blob container in Azure Blob Storage [slimm test]
     BLOB_CONTAINER: str = Field(default="test")

--- a/src/isar/storage/blob_storage.py
+++ b/src/isar/storage/blob_storage.py
@@ -59,7 +59,7 @@ class BlobStorage(StorageInterface):
 
         absolute_inspection_path = {
             "source": "blob",
-            "blob_storage_account_url": settings.BLOB_STORAGE_ACCOUNT_URL,
+            "storage_account": settings.BLOB_STORAGE_ACCOUNT,
             "blob_container": settings.BLOB_CONTAINER,
             "blob_name": blob_client.blob_name,
         }


### PR DESCRIPTION
to return just name of storage account instead of url. This also affects the config and must be considered when deploying the component and configuring environment variables.