### PR TITLE
Remove unused initializeParams

### DIFF
--- a/src/isar/state_machine/state_machine.py
+++ b/src/isar/state_machine/state_machine.py
@@ -29,7 +29,6 @@ from isar.state_machine.states.paused import Paused
 from isar.state_machine.states.stop import Stop
 from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
-from robot_interface.models.initialize.initialize_params import InitializeParams
 from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.status import MissionStatus, RobotStatus, TaskStatus
 from robot_interface.models.mission.task import TASKS
@@ -388,9 +387,6 @@ class StateMachine(object):
         self.initial_pose = initial_pose
 
         self.task_selector.initialize(tasks=self.current_mission.tasks)
-
-    def get_initialize_params(self):
-        return InitializeParams(initial_pose=self.initial_pose)
 
     def should_start_mission(self) -> Optional[StartMissionMessage]:
         try:

--- a/src/isar/state_machine/states/initialize.py
+++ b/src/isar/state_machine/states/initialize.py
@@ -45,8 +45,7 @@ class Initialize(State):
                     self.state_machine.robot.initialize
                 )
                 self.initialize_thread.start_thread(
-                    self.state_machine.get_initialize_params(),
-                    name="State Machine Initialize Robot",
+                    name="State Machine Initialize Robot"
                 )
 
             try:

--- a/src/robot_interface/models/exceptions/robot_exceptions.py
+++ b/src/robot_interface/models/exceptions/robot_exceptions.py
@@ -22,8 +22,6 @@ class ErrorReason(str, Enum):
     RobotTransformException = "robot_transform_exception"
     RobotUnknownErrorException = "robot_unknown_error_exception"
     RobotDisconnectedException = "robot_disconnected_exception"
-    RobotMissionNotSupportedException = "robot_mission_not_supported_exception"
-    RobotMissionMissingStartPoseException = "robot_mission_missing_start_pose_exception"
 
 
 @dataclass
@@ -255,28 +253,6 @@ class RobotDisconnectedException(RobotException):
     def __init__(self, error_description: str) -> None:
         super().__init__(
             error_reason=ErrorReason.RobotDisconnectedException,
-            error_description=error_description,
-        )
-
-    pass
-
-
-# An exception which should be thrown by the robot package if the robot is given a mission type it cannot run, such as a localisation mission
-class RobotMissionNotSupportedException(RobotException):
-    def __init__(self, error_description: str) -> None:
-        super().__init__(
-            error_reason=ErrorReason.RobotMissionNotSupportedException,
-            error_description=error_description,
-        )
-
-    pass
-
-
-# An exception which should be thrown by the robot package if the mission is missing start pose and it needed it
-class RobotMissionMissingStartPoseException(RobotException):
-    def __init__(self, error_description: str) -> None:
-        super().__init__(
-            error_reason=ErrorReason.RobotMissionMissingStartPoseException,
             error_description=error_description,
         )
 

--- a/src/robot_interface/models/initialize/initialize_params.py
+++ b/src/robot_interface/models/initialize/initialize_params.py
@@ -1,9 +1,0 @@
-from dataclasses import dataclass
-from typing import Optional
-
-from alitra import Pose
-
-
-@dataclass
-class InitializeParams:
-    initial_pose: Optional[Pose] = None

--- a/src/robot_interface/robot_interface.py
+++ b/src/robot_interface/robot_interface.py
@@ -3,7 +3,6 @@ from queue import Queue
 from threading import Thread
 from typing import Callable, List, Optional
 
-from robot_interface.models.initialize.initialize_params import InitializeParams
 from robot_interface.models.inspection.inspection import Inspection
 from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.status import RobotStatus, TaskStatus
@@ -186,14 +185,10 @@ class RobotInterface(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def initialize(self, params: InitializeParams) -> None:
+    def initialize(self) -> None:
         """Initializes the robot. The initialization needed is robot dependent and the
         function can be a simple return statement if no initialization is needed for the
         robot.
-
-        Parameters
-        ----------
-        params: InitializeParams
 
         Returns
         -------

--- a/tests/mocks/robot_interface.py
+++ b/tests/mocks/robot_interface.py
@@ -5,7 +5,6 @@ from typing import Callable, List
 
 from alitra import Frame, Orientation, Pose, Position
 
-from robot_interface.models.initialize.initialize_params import InitializeParams
 from robot_interface.models.inspection.inspection import (
     Image,
     ImageMetadata,
@@ -74,7 +73,7 @@ class MockRobot(RobotInterface):
     ) -> None:
         return
 
-    def initialize(self, params: InitializeParams) -> None:
+    def initialize(self) -> None:
         return
 
     def get_telemetry_publishers(


### PR DESCRIPTION
The commit "Remove unused initialize params" causes breaking-change and requires update of robot-interface in all isar-"robot" packages

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.