### PR TITLE
Revert "Use PAT for tests to run"

### DIFF
--- a/.github/workflows/compile_requirements.yml
+++ b/.github/workflows/compile_requirements.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # We need the Personal Access Token for the automated tests to run on the PR
-          token: ${{ secrets.PAT }}
           ssh-key: ${{ secrets.deploy_key }}
 
       - name: Set up Python

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - update-dependencies
 
 jobs:
   build:


### PR DESCRIPTION
This reverts commit 15bba7804ac0495a6bb3fb1de151afb3a445053c.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.