### PR TITLE
Add support for CO2 gas measurements

### DIFF
--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -12,7 +12,7 @@ from robot_interface.models.mission.task import (
     TASKS,
     RecordAudio,
     ReturnToHome,
-    TakeGasMeasurement,
+    TakeCO2Measurement,
     TakeImage,
     TakeThermalImage,
     TakeThermalVideo,
@@ -28,7 +28,7 @@ class InspectionTypes(str, Enum):
     video = "Video"
     thermal_video = "ThermalVideo"
     audio = "Audio"
-    gas_measurement = "GasMeasurement"
+    co2_measurement = "CO2Measurement"
 
 
 class TaskType(str, Enum):
@@ -148,8 +148,8 @@ def to_inspection_task(task_definition: StartMissionTaskDefinition) -> TASKS:
             target=task_definition.inspection.inspection_target.to_alitra_position(),
             duration=inspection_definition.duration,
         )
-    elif inspection_definition.type == InspectionTypes.gas_measurement:
-        return TakeGasMeasurement(
+    elif inspection_definition.type == InspectionTypes.co2_measurement:
+        return TakeCO2Measurement(
             id=task_definition.id if task_definition.id else uuid4_string(),
             robot_pose=task_definition.pose.to_alitra_pose(),
             tag_id=task_definition.tag,

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -228,6 +228,9 @@ class Settings(BaseSettings):
     TOPIC_ISAR_INSPECTION_RESULT: str = Field(
         default="inspection_result", validate_default=True
     )
+    TOPIC_ISAR_INSPECTION_VALUE: str = Field(
+        default="inspection_value", validate_default=True
+    )
     TOPIC_ISAR_ROBOT_INFO: str = Field(default="robot_info", validate_default=True)
     TOPIC_ISAR_ROBOT_HEARTBEAT: str = Field(
         default="robot_heartbeat", validate_default=True

--- a/src/isar/storage/uploader.py
+++ b/src/isar/storage/uploader.py
@@ -11,10 +11,17 @@ from dependency_injector.wiring import inject
 from isar.config.settings import settings
 from isar.models.communication.queues.events import Events
 from isar.storage.storage_interface import StorageException, StorageInterface
-from robot_interface.models.inspection.inspection import Inspection
+from robot_interface.models.inspection.inspection import (
+    Inspection,
+    InspectionBlob,
+    InspectionValue,
+)
 from robot_interface.models.mission.mission import Mission
 from robot_interface.telemetry.mqtt_client import MqttClientInterface
-from robot_interface.telemetry.payloads import InspectionResultPayload
+from robot_interface.telemetry.payloads import (
+    InspectionResultPayload,
+    InspectionValuePayload,
+)
 from robot_interface.utilities.json_service import EnhancedJSONEncoder
 
 
@@ -22,6 +29,16 @@ from robot_interface.utilities.json_service import EnhancedJSONEncoder
 class UploaderQueueItem:
     inspection: Inspection
     mission: Mission
+
+
+@dataclass
+class ValueItem(UploaderQueueItem):
+    inspection: InspectionValue
+
+
+@dataclass
+class BlobItem(UploaderQueueItem):
+    inspection: InspectionBlob
     storage_handler: StorageInterface
     _retry_count: int
     _next_retry_time: datetime = datetime.now(timezone.utc)
@@ -100,56 +117,116 @@ class Uploader:
                     )
                     continue
 
-                # If new item from thread queue, add one per handler to internal queue:
-                for storage_handler in self.storage_handlers:
-                    new_item: UploaderQueueItem = UploaderQueueItem(
-                        inspection, mission, storage_handler, _retry_count=-1
-                    )
+                new_item: UploaderQueueItem
+                if isinstance(inspection, InspectionValue):
+                    new_item = ValueItem(inspection, mission)
                     self._internal_upload_queue.append(new_item)
+
+                elif isinstance(inspection, InspectionBlob):
+                    # If new item from thread queue, add one per handler to internal queue:
+                    for storage_handler in self.storage_handlers:
+                        new_item = BlobItem(
+                            inspection, mission, storage_handler, _retry_count=-1
+                        )
+                        self._internal_upload_queue.append(new_item)
+                else:
+                    self.logger.warning(
+                        f"Unable to add UploaderQueueItem as its type {type(inspection).__name__} is unsupported"
+                    )
             except Empty:
                 continue
 
-    def _upload(self, upload_item: UploaderQueueItem) -> Union[str, dict]:
+    def _upload(self, item: BlobItem) -> Union[str, dict]:
         inspection_path: Union[str, dict] = ""
         try:
-            inspection_path = upload_item.storage_handler.store(
-                inspection=upload_item.inspection, mission=upload_item.mission
+            inspection_path = item.storage_handler.store(
+                inspection=item.inspection, mission=item.mission
             )
             self.logger.info(
-                f"Storage handler: {type(upload_item.storage_handler).__name__} "
-                f"uploaded inspection {str(upload_item.inspection.id)[:8]}"
+                f"Storage handler: {type(item.storage_handler).__name__} "
+                f"uploaded inspection {str(item.inspection.id)[:8]}"
             )
-            self._internal_upload_queue.remove(upload_item)
+            self._internal_upload_queue.remove(item)
         except StorageException:
-            if upload_item.get_retry_count() < self.max_retry_attempts:
-                upload_item.increment_retry(self.max_wait_time)
+            if item.get_retry_count() < self.max_retry_attempts:
+                item.increment_retry(self.max_wait_time)
                 self.logger.warning(
-                    f"Storage handler: {type(upload_item.storage_handler).__name__} "
+                    f"Storage handler: {type(item.storage_handler).__name__} "
                     f"failed to upload inspection: "
-                    f"{str(upload_item.inspection.id)[:8]}. "
-                    f"Retrying in {upload_item.seconds_until_retry()}s."
+                    f"{str(item.inspection.id)[:8]}. "
+                    f"Retrying in {item.seconds_until_retry()}s."
                 )
             else:
-                self._internal_upload_queue.remove(upload_item)
                 self.logger.error(
-                    f"Storage handler: {type(upload_item.storage_handler).__name__} "
+                    f"Storage handler: {type(item.storage_handler).__name__} "
                     f"exceeded max retries to upload inspection: "
-                    f"{str(upload_item.inspection.id)[:8]}. Aborting upload."
+                    f"{str(item.inspection.id)[:8]}. Aborting upload."
                 )
+                self._internal_upload_queue.remove(item)
         return inspection_path
 
     def _process_upload_queue(self) -> None:
+        def should_upload(_item):
+            if isinstance(_item, ValueItem):
+                return True
+            if _item.is_ready_for_upload():
+                return True
+            return False
+
         ready_items: List[UploaderQueueItem] = [
-            item for item in self._internal_upload_queue if item.is_ready_for_upload()
+            item for item in self._internal_upload_queue if should_upload(item)
         ]
         for item in ready_items:
-            inspection_path = self._upload(item)
-            self._publish_inspection_result(
-                inspection=item.inspection, inspection_path=inspection_path
+            if isinstance(item, ValueItem):
+                self._publish_inspection_value(item.inspection)
+                self.logger.info(
+                    f"Published value for inspection {str(item.inspection.id)[:8]}"
+                )
+                self._internal_upload_queue.remove(item)
+            elif isinstance(item, BlobItem):
+                inspection_path = self._upload(item)
+                self._publish_inspection_result(
+                    inspection=item.inspection, inspection_path=inspection_path
+                )
+            else:
+                self.logger.warning(
+                    f"Unable to process upload item as its type {type(item).__name__} is not supported"
+                )
+
+    def _publish_inspection_value(self, inspection: InspectionValue) -> None:
+        if not self.mqtt_publisher:
+            return
+
+        if not isinstance(inspection, InspectionValue):
+            logging.warning(
+                f"Excpected type InspectionValue but got {type(inspection).__name__} instead"
             )
+            return
+
+        payload: InspectionValuePayload = InspectionValuePayload(
+            isar_id=settings.ISAR_ID,
+            robot_name=settings.ROBOT_NAME,
+            inspection_id=inspection.id,
+            installation_code=settings.PLANT_SHORT_NAME,
+            tag_id=inspection.metadata.tag_id,
+            inspection_type=type(inspection).__name__,
+            inspection_description=inspection.metadata.inspection_description,
+            value=inspection.value,
+            unit=inspection.unit,
+            x=inspection.metadata.pose.position.x,
+            y=inspection.metadata.pose.position.y,
+            z=inspection.metadata.pose.position.z,
+            timestamp=inspection.metadata.start_time,
+        )
+        self.mqtt_publisher.publish(
+            topic=settings.TOPIC_ISAR_INSPECTION_VALUE,
+            payload=json.dumps(payload, cls=EnhancedJSONEncoder),
+            qos=1,
+            retain=True,
+        )
 
     def _publish_inspection_result(
-        self, inspection: Inspection, inspection_path: Union[str, dict]
+        self, inspection: InspectionBlob, inspection_path: Union[str, dict]
     ) -> None:
         """Publishes the reference of the inspection result to the MQTT Broker
         along with the analysis type

--- a/src/robot_interface/models/inspection/inspection.py
+++ b/src/robot_interface/models/inspection/inspection.py
@@ -49,14 +49,22 @@ class GasMeasurementMetadata(InspectionMetadata):
 class Inspection(BaseModel):
     metadata: InspectionMetadata
     id: str = Field(frozen=True)
-    data: Optional[bytes] = Field(default=None, frozen=True)
 
     @staticmethod
     def get_metadata_type() -> Type[InspectionMetadata]:
         return InspectionMetadata
 
 
-class Image(Inspection):
+class InspectionValue(Inspection):
+    value: float = Field(frozen=True)
+    unit: str = Field(frozen=True)
+
+
+class InspectionBlob(Inspection):
+    data: Optional[bytes] = Field(default=None, frozen=True)
+
+
+class Image(InspectionBlob):
     metadata: ImageMetadata
 
     @staticmethod
@@ -64,7 +72,7 @@ class Image(Inspection):
         return ImageMetadata
 
 
-class ThermalImage(Inspection):
+class ThermalImage(InspectionBlob):
     metadata: ThermalImageMetadata
 
     @staticmethod
@@ -72,7 +80,7 @@ class ThermalImage(Inspection):
         return ThermalImageMetadata
 
 
-class Video(Inspection):
+class Video(InspectionBlob):
     metadata: VideoMetadata
 
     @staticmethod
@@ -80,7 +88,7 @@ class Video(Inspection):
         return VideoMetadata
 
 
-class ThermalVideo(Inspection):
+class ThermalVideo(InspectionBlob):
     metadata: ThermalVideoMetadata
 
     @staticmethod
@@ -88,7 +96,7 @@ class ThermalVideo(Inspection):
         return ThermalVideoMetadata
 
 
-class Audio(Inspection):
+class Audio(InspectionBlob):
     metadata: AudioMetadata
 
     @staticmethod
@@ -96,9 +104,13 @@ class Audio(Inspection):
         return AudioMetadata
 
 
-class GasMeasurement(Inspection):
+class GasMeasurement(InspectionValue):
     metadata: GasMeasurementMetadata
 
     @staticmethod
     def get_metadata_type() -> Type[InspectionMetadata]:
         return GasMeasurementMetadata
+
+
+class CO2Measurement(GasMeasurement):
+    pass

--- a/src/robot_interface/models/mission/task.py
+++ b/src/robot_interface/models/mission/task.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
 from robot_interface.models.inspection.inspection import (
     Audio,
-    GasMeasurement,
+    CO2Measurement,
     Image,
     Inspection,
     ThermalImage,
@@ -25,7 +25,7 @@ class TaskTypes(str, Enum):
     TakeThermalImage = "take_thermal_image"
     TakeVideo = "take_video"
     TakeThermalVideo = "take_thermal_video"
-    TakeGasMeasurement = "take_gas_measurement"
+    TakeCO2Measurement = "take_co2_measurement"
     RecordAudio = "record_audio"
 
 
@@ -160,18 +160,16 @@ class RecordAudio(InspectionTask):
         return Audio
 
 
-class TakeGasMeasurement(InspectionTask):
+class TakeCO2Measurement(InspectionTask):
     """
     Task which causes the robot to take a CO2 measurement at its position.
-
-    Duration of audio is given in seconds.
     """
 
-    type: Literal[TaskTypes.TakeGasMeasurement] = TaskTypes.TakeGasMeasurement
+    type: Literal[TaskTypes.TakeCO2Measurement] = TaskTypes.TakeCO2Measurement
 
     @staticmethod
     def get_inspection_type() -> Type[Inspection]:
-        return GasMeasurement
+        return CO2Measurement
 
 
 TASKS = Union[
@@ -181,6 +179,6 @@ TASKS = Union[
     TakeThermalImage,
     TakeVideo,
     TakeThermalVideo,
-    TakeGasMeasurement,
+    TakeCO2Measurement,
     RecordAudio,
 ]

--- a/src/robot_interface/telemetry/payloads.py
+++ b/src/robot_interface/telemetry/payloads.py
@@ -115,3 +115,20 @@ class InspectionResultPayload:
     inspection_type: Optional[str]
     inspection_description: Optional[str]
     timestamp: datetime
+
+
+@dataclass
+class InspectionValuePayload:
+    isar_id: str
+    robot_name: str
+    inspection_id: str
+    installation_code: str
+    tag_id: Optional[str]
+    inspection_type: Optional[str]
+    inspection_description: Optional[str]
+    value: float
+    unit: str
+    x: float
+    y: float
+    z: float
+    timestamp: datetime

--- a/tests/isar/storage/test_uploader.py
+++ b/tests/isar/storage/test_uploader.py
@@ -6,7 +6,11 @@ from alitra import Frame, Orientation, Pose, Position
 
 from isar.modules import ApplicationContainer
 from isar.storage.uploader import Uploader
-from robot_interface.models.inspection.inspection import ImageMetadata, Inspection
+from robot_interface.models.inspection.inspection import (
+    ImageMetadata,
+    Inspection,
+    InspectionBlob,
+)
 from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.task import TakeImage
 from tests.isar.state_machine.test_state_machine import UploaderThreadMock
@@ -33,7 +37,7 @@ def test_should_upload_from_queue(
     mission: Mission = Mission(name="Dummy misson", tasks=[take_image_task])
 
     assert isinstance(mission.tasks[0], TakeImage)
-    inspection = Inspection(
+    inspection = InspectionBlob(
         metadata=ARBITRARY_IMAGE_METADATA, id=mission.tasks[0].inspection_id
     )
 
@@ -57,7 +61,7 @@ def test_should_retry_failed_upload_from_queue(
     uploader_thread.start()
 
     INSPECTION_ID = "123-456"
-    inspection = Inspection(metadata=ARBITRARY_IMAGE_METADATA, id=INSPECTION_ID)
+    inspection = InspectionBlob(metadata=ARBITRARY_IMAGE_METADATA, id=INSPECTION_ID)
     mission: Mission = Mission(name="Dummy Mission")
 
     message: Tuple[Inspection, Mission] = (


### PR DESCRIPTION
The system will now be able to handle incoming CO2 gas measurements from the robots. Additionally, the framework is set up to easily support future implementations with other types of values to be reported.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.