### PR TITLE
Add support for CO2 gas measurements

### DIFF
--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -12,7 +12,7 @@ from robot_interface.models.mission.task import (
     TASKS,
     RecordAudio,
     ReturnToHome,
-    TakeGasMeasurement,
+    TakeCO2Measurement,
     TakeImage,
     TakeThermalImage,
     TakeThermalVideo,
@@ -28,7 +28,7 @@ class InspectionTypes(str, Enum):
     video = "Video"
     thermal_video = "ThermalVideo"
     audio = "Audio"
-    gas_measurement = "GasMeasurement"
+    co2_measurement = "CO2Measurement"
 
 
 class TaskType(str, Enum):
@@ -148,8 +148,8 @@ def to_inspection_task(task_definition: StartMissionTaskDefinition) -> TASKS:
             target=task_definition.inspection.inspection_target.to_alitra_position(),
             duration=inspection_definition.duration,
         )
-    elif inspection_definition.type == InspectionTypes.gas_measurement:
-        return TakeGasMeasurement(
+    elif inspection_definition.type == InspectionTypes.co2_measurement:
+        return TakeCO2Measurement(
             id=task_definition.id if task_definition.id else uuid4_string(),
             robot_pose=task_definition.pose.to_alitra_pose(),
             tag_id=task_definition.tag,

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -228,6 +228,9 @@ class Settings(BaseSettings):
     TOPIC_ISAR_INSPECTION_RESULT: str = Field(
         default="inspection_result", validate_default=True
     )
+    TOPIC_ISAR_INSPECTION_VALUE: str = Field(
+        default="inspection_value", validate_default=True
+    )
     TOPIC_ISAR_ROBOT_INFO: str = Field(default="robot_info", validate_default=True)
     TOPIC_ISAR_ROBOT_HEARTBEAT: str = Field(
         default="robot_heartbeat", validate_default=True

--- a/src/robot_interface/models/inspection/inspection.py
+++ b/src/robot_interface/models/inspection/inspection.py
@@ -1,10 +1,9 @@
 from abc import ABC
+from alitra import Pose
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, Type
-
-from alitra import Pose
 from pydantic import BaseModel, Field
+from typing import Optional, Type
 
 
 @dataclass
@@ -49,14 +48,22 @@ class GasMeasurementMetadata(InspectionMetadata):
 class Inspection(BaseModel):
     metadata: InspectionMetadata
     id: str = Field(frozen=True)
-    data: Optional[bytes] = Field(default=None, frozen=True)
 
     @staticmethod
     def get_metadata_type() -> Type[InspectionMetadata]:
         return InspectionMetadata
 
 
-class Image(Inspection):
+class InspectionValue(Inspection):
+    value: float = Field(frozen=True)
+    unit: str = Field(frozen=True)
+
+
+class InspectionBlob(Inspection):
+    data: Optional[bytes] = Field(default=None, frozen=True)
+
+
+class Image(InspectionBlob):
     metadata: ImageMetadata
 
     @staticmethod
@@ -64,7 +71,7 @@ class Image(Inspection):
         return ImageMetadata
 
 
-class ThermalImage(Inspection):
+class ThermalImage(InspectionBlob):
     metadata: ThermalImageMetadata
 
     @staticmethod
@@ -72,7 +79,7 @@ class ThermalImage(Inspection):
         return ThermalImageMetadata
 
 
-class Video(Inspection):
+class Video(InspectionBlob):
     metadata: VideoMetadata
 
     @staticmethod
@@ -80,7 +87,7 @@ class Video(Inspection):
         return VideoMetadata
 
 
-class ThermalVideo(Inspection):
+class ThermalVideo(InspectionBlob):
     metadata: ThermalVideoMetadata
 
     @staticmethod
@@ -88,7 +95,7 @@ class ThermalVideo(Inspection):
         return ThermalVideoMetadata
 
 
-class Audio(Inspection):
+class Audio(InspectionBlob):
     metadata: AudioMetadata
 
     @staticmethod
@@ -96,9 +103,13 @@ class Audio(Inspection):
         return AudioMetadata
 
 
-class GasMeasurement(Inspection):
+class GasMeasurement(InspectionValue):
     metadata: GasMeasurementMetadata
 
     @staticmethod
     def get_metadata_type() -> Type[InspectionMetadata]:
         return GasMeasurementMetadata
+
+
+class CO2Measurement(GasMeasurement):
+    pass

--- a/src/robot_interface/models/mission/task.py
+++ b/src/robot_interface/models/mission/task.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
 from robot_interface.models.inspection.inspection import (
     Audio,
-    GasMeasurement,
+    CO2Measurement,
     Image,
     Inspection,
     ThermalImage,
@@ -25,7 +25,7 @@ class TaskTypes(str, Enum):
     TakeThermalImage = "take_thermal_image"
     TakeVideo = "take_video"
     TakeThermalVideo = "take_thermal_video"
-    TakeGasMeasurement = "take_gas_measurement"
+    TakeCO2Measurement = "take_co2_measurement"
     RecordAudio = "record_audio"
 
 
@@ -160,18 +160,16 @@ class RecordAudio(InspectionTask):
         return Audio
 
 
-class TakeGasMeasurement(InspectionTask):
+class TakeCO2Measurement(InspectionTask):
     """
     Task which causes the robot to take a CO2 measurement at its position.
-
-    Duration of audio is given in seconds.
     """
 
-    type: Literal[TaskTypes.TakeGasMeasurement] = TaskTypes.TakeGasMeasurement
+    type: Literal[TaskTypes.TakeCO2Measurement] = TaskTypes.TakeCO2Measurement
 
     @staticmethod
     def get_inspection_type() -> Type[Inspection]:
-        return GasMeasurement
+        return CO2Measurement
 
 
 TASKS = Union[
@@ -181,6 +179,6 @@ TASKS = Union[
     TakeThermalImage,
     TakeVideo,
     TakeThermalVideo,
-    TakeGasMeasurement,
+    TakeCO2Measurement,
     RecordAudio,
 ]

--- a/src/robot_interface/telemetry/payloads.py
+++ b/src/robot_interface/telemetry/payloads.py
@@ -115,3 +115,20 @@ class InspectionResultPayload:
     inspection_type: Optional[str]
     inspection_description: Optional[str]
     timestamp: datetime
+
+
+@dataclass
+class InspectionValuePayload:
+    isar_id: str
+    robot_name: str
+    inspection_id: str
+    installation_code: str
+    tag_id: Optional[str]
+    inspection_type: Optional[str]
+    inspection_description: Optional[str]
+    value: float
+    unit: str
+    x: float
+    y: float
+    z: float
+    timestamp: datetime


### PR DESCRIPTION
The system will now be able to handle incoming CO2 gas measurements from the robots. Additionally, the framework is set up to easily support future implementations with other types of values to be reported.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.