### PR TITLE
Reduce calls to robot_status on failed fetching of status

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
     ROBOT_HEARTBEAT_PUBLISH_INTERVAL: float = Field(default=1)
     ROBOT_INFO_PUBLISH_INTERVAL: float = Field(default=5)
     ROBOT_API_STATUS_POLL_INTERVAL: float = Field(default=5)
+    THREAD_CHECK_INTERVAL: float = Field(default=0.01)
 
     # FastAPI host
     API_HOST_VIEWED_EXTERNALLY: str = Field(default="0.0.0.0")

--- a/src/isar/robot/robot_status.py
+++ b/src/isar/robot/robot_status.py
@@ -40,14 +40,16 @@ class RobotStatusThread(Thread):
         if self.signal_thread_quitting.is_set():
             return
 
-        while not self.signal_thread_quitting.wait(0.001):
+        thread_check_interval = settings.THREAD_CHECK_INTERVAL
+
+        while not self.signal_thread_quitting.wait(thread_check_interval):
             if not self._is_ready_to_poll_for_status():
                 continue
             try:
-                robot_status = self.robot.robot_status()
-
-                update_shared_state(self.shared_state.robot_status, robot_status)
                 self.last_robot_status_poll_time = time.time()
+
+                robot_status = self.robot.robot_status()
+                update_shared_state(self.shared_state.robot_status, robot_status)
             except RobotException as e:
                 self.logger.error(f"Failed to retrieve robot status: {e}")
                 continue


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.


I believe the repeated logs happened because the function throws error in roboy_status and does not update the poll time, however I am not sure.

```python
    while not self.signal_thread_quitting.wait(0.001):
            if not self._is_ready_to_poll_for_status(): #1 & 4: This is true
                continue
            try:
                robot_status = self.robot.robot_status() # <-- 2: ERROR here, throws exception

                update_shared_state(self.shared_state.robot_status, robot_status)
                self.last_robot_status_poll_time = time.time() # <-- 3: Upon error this does not get called, meaning self._is_ready_to_poll_for_status() will always be true 
            except RobotException as e:
                self.logger.error(f"Failed to retrieve robot status: {e}")
                continue
```

1: _is_ready_to_poll_for_status is true
2: tries to call robot status but throws error and exits out of try statement
3: This does not get called
4: _is_ready_to_poll_for_status is still true since the time has not been updated


In the updated code the `self.last_robot_status_poll_time = time.time()` is put first in the try, ensuring it is updated even if robot_status throws exception. This should ensure that it takes 5 seconds for the next try.