### PR TITLE
Add error handling for pause and resume

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -52,6 +52,12 @@ class Settings(BaseSettings):
     # issues
     REQUEST_STATUS_COMMUNICATION_RECONNECT_DELAY: float = Field(default=10)
 
+    # Number of attempts for state transitions resume and pause if failed
+    STATE_TRANSITION_NUM_RETIRES: int = Field(default=10)
+
+    # Interval between attempt of state transition
+    STATE_TRANSITION_RETRY_INTERVAL_SEC: float = Field(default=1)
+
     # Number of attempts to stop the robot before giving up
     STOP_ROBOT_ATTEMPTS_LIMIT: int = Field(default=3)
 

--- a/src/isar/state_machine/transitions/functions/pause.py
+++ b/src/isar/state_machine/transitions/functions/pause.py
@@ -3,7 +3,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from isar.state_machine.state_machine import StateMachine
 
+import time
+
 from isar.apis.models.models import ControlMissionResponse
+from isar.config.settings import settings
+from robot_interface.models.exceptions.robot_exceptions import (
+    RobotActionException,
+    RobotException,
+)
 from robot_interface.models.mission.status import MissionStatus, TaskStatus
 
 
@@ -20,5 +27,24 @@ def pause_mission(state_machine: "StateMachine") -> bool:
     state_machine.publish_mission_status()
     state_machine.publish_task_status(task=state_machine.current_task)
 
-    state_machine.robot.pause()
-    return True
+    max_retries = settings.STATE_TRANSITION_NUM_RETIRES
+    retry_interval = settings.STATE_TRANSITION_RETRY_INTERVAL_SEC
+
+    for attempt in range(max_retries):
+        try:
+            state_machine.robot.pause()
+            state_machine.logger.info("Mission paused successfully.")
+            return True
+        except RobotActionException as e:
+            state_machine.logger.warning(
+                f"Attempt {attempt + 1} to pause mission failed: {e.error_description}"
+            )
+            time.sleep(retry_interval)
+        except RobotException as e:
+            state_machine.logger.warning(
+                f"Attempt {attempt + 1} to pause mission raised a RobotException: {e.error_description}"
+            )
+            time.sleep(retry_interval)
+
+    state_machine.logger.error("Failed to pause mission after multiple attempts.")
+    return False

--- a/src/isar/state_machine/transitions/functions/resume.py
+++ b/src/isar/state_machine/transitions/functions/resume.py
@@ -3,7 +3,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from isar.state_machine.state_machine import StateMachine
 
+import time
+
 from isar.apis.models.models import ControlMissionResponse
+from isar.config.settings import settings
+from robot_interface.models.exceptions.robot_exceptions import (
+    RobotActionException,
+    RobotException,
+)
 from robot_interface.models.mission.status import MissionStatus, TaskStatus
 
 
@@ -23,5 +30,24 @@ def resume_mission(state_machine: "StateMachine") -> bool:
     )
     state_machine.events.api_requests.resume_mission.output.put(resume_mission_response)
 
-    state_machine.robot.resume()
-    return True
+    max_retries = settings.STATE_TRANSITION_NUM_RETIRES
+    retry_interval = settings.STATE_TRANSITION_RETRY_INTERVAL_SEC
+
+    for attempt in range(max_retries):
+        try:
+            state_machine.robot.resume()
+            state_machine.logger.info("Mission resumed successfully.")
+            return True
+        except RobotActionException as e:
+            state_machine.logger.warning(
+                f"Attempt {attempt + 1} to resume mission failed: {e.error_description}"
+            )
+            time.sleep(retry_interval)
+        except RobotException as e:
+            state_machine.logger.warning(
+                f"Attempt {attempt + 1} to resume mission raised a RobotException: {e.error_description}"
+            )
+            time.sleep(retry_interval)
+
+    state_machine.logger.error("Failed to resume mission after multiple attempts.")
+    return False


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.


**Note to reviewers**:
- Do we have a state for the state machine if state transitions repeatedly fails?
- Introduced behaviour is try x amount of times and then it gets the new state anyway, do we have a better way?
- API appearently just returns "Mission successfully paused" even before the function pause function has exited


**Previous behavior**
Isar crashed when isar-robot raised RobotActionException and fully exited

**Introduced behaviour when pause fails**

```bash
2025-07-02 13:56:14,046 - INFO:     - state_machine - Pausing mission: 077a8ffd-ff27-40f2-8d7f-15b00fed9c08
2025-07-02 13:56:14,058 - WARNING:  - state_machine - Attempt 1 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:14,063 - INFO:     - api - OK - Mission successfully paused
2025-07-02 13:56:15,077 - WARNING:  - state_machine - Attempt 2 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:16,096 - WARNING:  - state_machine - Attempt 3 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:17,125 - WARNING:  - state_machine - Attempt 4 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:18,142 - WARNING:  - state_machine - Attempt 5 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:19,159 - WARNING:  - state_machine - Attempt 6 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:20,196 - WARNING:  - state_machine - Attempt 7 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:21,217 - WARNING:  - state_machine - Attempt 8 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:22,230 - WARNING:  - state_machine - Attempt 9 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:23,243 - WARNING:  - state_machine - Attempt 10 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:56:24,264 - ERROR:    - state_machine - Failed to pause mission after multiple attempts.
2025-07-02 13:56:24,277 - INFO:     - state_machine - State: States.Paused
```

**Introduced behaviour retries in pause and resume that eventually succeeds**
 ```bash
 2025-07-02 13:57:53,370 - INFO:     - state_machine - Pausing mission: f19cd202-b6b3-49b1-a1af-31def34a52d2
2025-07-02 13:57:53,382 - WARNING:  - state_machine - Attempt 1 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:57:53,389 - INFO:     - api - OK - Mission successfully paused
2025-07-02 13:57:54,399 - WARNING:  - state_machine - Attempt 2 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:57:55,413 - WARNING:  - state_machine - Attempt 3 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:57:56,429 - WARNING:  - state_machine - Attempt 4 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:57:57,447 - WARNING:  - state_machine - Attempt 5 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:57:58,465 - WARNING:  - state_machine - Attempt 6 to pause mission failed: Robot randomly failed to schedule mission
2025-07-02 13:57:59,494 - INFO:     - state_machine - Mission paused successfully.
2025-07-02 13:57:59,513 - INFO:     - state_machine - State: States.Paused
2025-07-02 13:58:01,652 - INFO:     - api - Received request to resume current mission
2025-07-02 13:58:01,681 - INFO:     - state_machine - Resuming mission: f19cd202-b6b3-49b1-a1af-31def34a52d2
2025-07-02 13:58:01,692 - WARNING:  - state_machine - Attempt 1 to resume mission failed: Robot randomly failed to schedule mission
2025-07-02 13:58:01,702 - INFO:     - api - OK - Mission successfully resumed
2025-07-02 13:58:02,709 - WARNING:  - state_machine - Attempt 2 to resume mission failed: Robot randomly failed to schedule mission
2025-07-02 13:58:03,736 - INFO:     - state_machine - Mission resumed successfully.
2025-07-02 13:58:03,746 - INFO:     - state_machine - State: States.Monitor
2025-07-02 13:58:03,870 - INFO:     - state_machine - TakeImage task: 8088ee3c completed
2025-07-02 13:58:03,928 - INFO:     - state_machine - Inspection result: ed60b12b queued for upload
2025-07-02 13:58:03,990 - INFO:     - uploader - Storage handler: LocalStorage uploaded inspection ed60b12b

 ```