### PR TITLE
Suggest fix type errors for nullable types

### DIFF
--- a/src/isar/state_machine/state_machine.py
+++ b/src/isar/state_machine/state_machine.py
@@ -168,6 +168,9 @@ class StateMachine(object):
         self.signal_state_machine_to_stop.set()
 
     def iterate_current_task(self):
+        if self.current_task is None:
+            raise ValueError("No current task is set")
+
         if self.current_task.is_finished():
             try:
                 self.current_task = self.task_selector.next_task()
@@ -313,6 +316,12 @@ class StateMachine(object):
         self.logger.info("Mission overview:\n%s", log_statement)
 
     def _make_control_mission_response(self) -> ControlMissionResponse:
+        if self.current_mission is None:
+            raise ValueError("No current mission is set")
+
+        if self.current_task is None:
+            raise ValueError("No current task is set")
+
         return ControlMissionResponse(
             mission_id=self.current_mission.id,
             mission_status=self.current_mission.status,


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.


Should we fix type errors for nullable types? 
I get type errors in my editor for quite many types which are defined with 
```python
somevar: Optional[sometype] = somevalue
```

![image](https://github.com/user-attachments/assets/5d59ce96-54a3-4b2f-9712-ae10471373d9)


and we try to use them without checking for none, e.g.
```python
somevar.somevalue
```

A fix to this is to have some if guards at the top of each function validating that they are not null and raising exceptions if they are

```python
if somevar is None:
    raise ValueError("Somevar is not set")
# and then access
somevar.somevalue
```

A pro with this approach is that we can make our codebase fully type safe

A con of this approach is that we get quite many places in the codebase we check for this even if reasonably know well that they are not null in that specific instance

Can continue to fix more type errors if we go for this approach. There are quite a lot more