### PR TITLE
Make demo for uv with isar and isar-robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Steps:
 - Run the ISAR server
 - Run a robot mission
 
+
 ### Install
 
 For local development, please fork the repository. Then, clone and install in the repository root folder:
@@ -24,6 +25,36 @@ For local development, please fork the repository. Then, clone and install in th
 ```
 git clone https://github.com/<path_to_parent>/isar
 cd isar
+```
+
+## uv method
+
+Assuming isar-robot is cloned at ../isar-robot relative to isar
+
+```
+uv run --group local --env-file envs/local.vars main.py
+```
+
+```
+python -m venv venv
+source venv/bin/activate
+cd ../isar-robot
+pip install -e ".[dev]"
+cd ../isar
+pip install -e ".[dev]"
+EXPORT ISAR_MQTT_ENABLED=True
+python main.py
+```
+
+
+##
+```
+
+```
+
+
+
+```
 pip install -e .[dev]
 ```
 

--- a/envs/local.vars
+++ b/envs/local.vars
@@ -1,0 +1,1 @@
+ISAR_MQTT_ENABLED=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,11 @@ use_parentheses = true
 
 [tool.black]
 line_length = 88
+
+[dependency-groups]
+local = [
+    "isar-robot"
+]
+
+[tool.uv.sources]
+isar-robot = { path = "../isar-robot", editable = true }


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.


Demo how uv package manager can simplify setup for running with for example isar robot

**Assuming:**
- Assuming isar-robot is cloned at ../isar-robot relative to isar
- uv is installed, [link](https://docs.astral.sh/uv/getting-started/installation/)
- pyproject.toml in isar-robot is installed like this
dependencies = ["alitra", "isar"] with no isar>1.30

**uv method**:
```
uv run --group local --env-file envs/local.vars main.py
```

**current method**:
```
python -m venv venv
source venv/bin/activate
cd ../isar-robot
pip install -e ".[dev]"
cd ../isar
pip install -e ".[dev]"
EXPORT ISAR_MQTT_ENABLED=True
python main.py
```
