### PR TITLE
Remove writing to log files

### DIFF
--- a/src/isar/config/log.py
+++ b/src/isar/config/log.py
@@ -5,11 +5,10 @@ from importlib.resources import as_file, files
 import yaml
 from uvicorn.logging import ColourizedFormatter
 
-from isar.config.keyvault.keyvault_service import Keyvault
 from isar.config.settings import settings
 
 
-def setup_loggers(keyvault: Keyvault) -> None:
+def setup_loggers() -> None:
     log_levels: dict = settings.LOG_LEVELS
     log_config = load_log_config()
 

--- a/src/isar/config/logging.conf
+++ b/src/isar/config/logging.conf
@@ -5,50 +5,29 @@ formatters:
   colourized:
     style: "{"
     format: "{asctime} - {levelprefix:<8} - {name} - {message}"
-handlers:
-  api:
-    class: logging.FileHandler
-    formatter: simple
-    filename: api.log
-  main:
-    class: logging.FileHandler
-    formatter: simple
-    filename: main.log
-  mqtt:
-    class: logging.FileHandler
-    formatter: simple
-    filename: mqtt.log
-  state_machine:
-    class: logging.FileHandler
-    formatter: simple
-    filename: state_machine.log
-  uploader:
-    class: logging.FileHandler
-    formatter: simple
-    filename: uploader.log
 loggers:
   console:
     handlers: []
     propagate: no
   main:
-    handlers: [main]
+    handlers: []
     propagate: no
   api:
-    handlers: [api]
+    handlers: []
     propagate: no
   mqtt:
-    handlers: [mqtt]
-    propagate: False
+    handlers: []
+    propagate: no
   state_machine:
-    handlers: [state_machine]
-    propagate: False
+    handlers: []
+    propagate: no
   uploader:
-    handlers: [uploader]
-    propagate: False
+    handlers: []
+    propagate: no
   urllib3:
     handlers: []
   uvicorn:
-    handlers: [api]
+    handlers: []
     propagate: no
   azure:
     handlers: []

--- a/src/isar/script.py
+++ b/src/isar/script.py
@@ -75,8 +75,7 @@ def print_startup_info():
 def start() -> None:
     injector: ApplicationContainer = get_injector()
 
-    keyvault = injector.keyvault()
-    setup_loggers(keyvault=keyvault)
+    setup_loggers()
     setup_open_telemetry(app=injector.api().app)
     logger: Logger = logging.getLogger("main")
 


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.

The current setup writes to log files, however as to my knowledge we do not use the log files for anything. Disabling them could enable us running with readOnlyRootFilesystem increasing the security posture in Kubernetes