### PR TITLE
Don't start missions when battery is too low

### DIFF
--- a/src/isar/apis/models/models.py
+++ b/src/isar/apis/models/models.py
@@ -26,6 +26,12 @@ class ControlMissionResponse(BaseModel):
     task_status: Optional[str]
 
 
+class MissionStartResponse(BaseModel):
+    mission_id: Optional[str] = None
+    mission_started: bool
+    mission_not_started_reason: Optional[str] = None
+
+
 class RobotInfoResponse(BaseModel):
     robot_package: str
     isar_id: str

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -81,6 +81,9 @@ class Settings(BaseSettings):
     ROBOT_API_STATUS_POLL_INTERVAL: float = Field(default=5)
     THREAD_CHECK_INTERVAL: float = Field(default=0.01)
 
+    # Determines the minimum battery level the robot must have to start a mission
+    ROBOT_MISSION_BATTERY_START_THRESHOLD: float = Field(default=25.0)
+
     # FastAPI host
     API_HOST_VIEWED_EXTERNALLY: str = Field(default="0.0.0.0")
 

--- a/src/isar/eventhandlers/eventhandler.py
+++ b/src/isar/eventhandlers/eventhandler.py
@@ -58,6 +58,28 @@ class EventHandlerBase(State):
     def stop(self) -> None:
         return
 
+    def get_event_handler_by_name(
+        self, event_handler_name: str
+    ) -> Optional[EventHandlerMapping]:
+        filtered_handlers = list(
+            filter(
+                lambda mapping: mapping.name == event_handler_name,
+                self.event_handler_mappings,
+            )
+        )
+        return filtered_handlers[0] if len(filtered_handlers) > 0 else None
+
+    def get_event_timer_by_name(
+        self, event_timer_name: str
+    ) -> Optional[TimeoutHandlerMapping]:
+        filtered_timers = list(
+            filter(
+                lambda mapping: mapping.name == event_timer_name,
+                self.timers,
+            )
+        )
+        return filtered_timers[0] if len(filtered_timers) > 0 else None
+
     def _run(self) -> None:
         should_exit_state: bool = False
         timers = deepcopy(self.timers)

--- a/src/isar/robot/robot_status.py
+++ b/src/isar/robot/robot_status.py
@@ -48,7 +48,10 @@ class RobotStatusThread(Thread):
                 self.last_robot_status_poll_time = time.time()
 
                 robot_status = self.robot.robot_status()
+                robot_battery_level = self.robot.get_battery_level()
+
                 self.shared_state.robot_status.update(robot_status)
+                self.shared_state.robot_battery_level.update(robot_battery_level)
             except RobotException as e:
                 self.logger.error(f"Failed to retrieve robot status: {e}")
                 continue

--- a/src/isar/state_machine/state_machine.py
+++ b/src/isar/state_machine/state_machine.py
@@ -189,6 +189,12 @@ class StateMachine(object):
                 self.current_task = None
             self.send_task_status()
 
+    def battery_level_is_above_mission_start_threshold(self):
+        return (
+            not self.shared_state.robot_battery_level.check()
+            < settings.ROBOT_MISSION_BATTERY_START_THRESHOLD
+        )
+
     def update_state(self):
         """Updates the current state of the state machine."""
         self.current_state = States(self.state)  # type: ignore

--- a/src/isar/state_machine/states/await_next_mission.py
+++ b/src/isar/state_machine/states/await_next_mission.py
@@ -25,7 +25,9 @@ class AwaitNextMission(EventHandlerBase):
             EventHandlerMapping(
                 name="start_mission_event",
                 event=events.api_requests.start_mission.request,
-                handler=lambda event: start_mission_event_handler(state_machine, event),
+                handler=lambda event: start_mission_event_handler(
+                    state_machine, event, events.api_requests.start_mission.response
+                ),
             ),
             EventHandlerMapping(
                 name="return_home_event",

--- a/src/isar/state_machine/states/home.py
+++ b/src/isar/state_machine/states/home.py
@@ -23,7 +23,9 @@ class Home(EventHandlerBase):
             EventHandlerMapping(
                 name="start_mission_event",
                 event=events.api_requests.start_mission.request,
-                handler=lambda event: start_mission_event_handler(state_machine, event),
+                handler=lambda event: start_mission_event_handler(
+                    state_machine, event, events.api_requests.start_mission.response
+                ),
             ),
             EventHandlerMapping(
                 name="return_home_event",

--- a/src/isar/state_machine/states/returning_home.py
+++ b/src/isar/state_machine/states/returning_home.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Callable, List, Optional
 
+from isar.apis.models.models import MissionStartResponse
 from isar.eventhandlers.eventhandler import EventHandlerBase, EventHandlerMapping
-from isar.models.events import Event
+from isar.models.events import Event, EventTimeoutError
 from isar.state_machine.utils.common_event_handlers import (
     mission_failed_event_handler,
     mission_started_event_handler,
@@ -38,6 +39,19 @@ class ReturningHome(EventHandlerBase):
             event: Event[Mission],
         ) -> Optional[Callable]:
             if event.has_event():
+                if not state_machine.battery_level_is_above_mission_start_threshold():
+                    try:
+                        state_machine.events.api_requests.start_mission.response.trigger_event(
+                            MissionStartResponse(
+                                mission_id=None,
+                                mission_started=False,
+                                mission_not_started_reason="Robot battery too low",
+                            ),
+                            timeout=1,  # This conflict can happen if two API requests are received at the same time
+                        )
+                    except EventTimeoutError:
+                        pass
+                    return None
                 return state_machine.stop  # type: ignore
             return None
 

--- a/src/isar/state_machine/states/robot_standing_still.py
+++ b/src/isar/state_machine/states/robot_standing_still.py
@@ -23,7 +23,9 @@ class RobotStandingStill(EventHandlerBase):
             EventHandlerMapping(
                 name="start_mission_event",
                 event=events.api_requests.start_mission.request,
-                handler=lambda event: start_mission_event_handler(state_machine, event),
+                handler=lambda event: start_mission_event_handler(
+                    state_machine, event, events.api_requests.start_mission.response
+                ),
             ),
             EventHandlerMapping(
                 name="return_home_event",

--- a/src/isar/state_machine/transitions/functions/start_mission.py
+++ b/src/isar/state_machine/transitions/functions/start_mission.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from isar.state_machine.state_machine import StateMachine
 
+from isar.apis.models.models import MissionStartResponse
 from robot_interface.models.exceptions.robot_exceptions import (
     ErrorMessage,
     RobotException,
@@ -12,7 +13,9 @@ from robot_interface.models.mission.status import MissionStatus, TaskStatus
 
 
 def acknowledge_mission(state_machine: "StateMachine") -> bool:
-    state_machine.events.api_requests.start_mission.response.put(True)
+    state_machine.events.api_requests.start_mission.response.put(
+        MissionStartResponse(mission_started=True)
+    )
     return True
 
 
@@ -70,5 +73,10 @@ def trigger_start_mission_event(state_machine: "StateMachine") -> bool:
 
 
 def _initialization_failed(state_machine: "StateMachine") -> None:
-    state_machine.events.api_requests.start_mission.response.put(False)
+    state_machine.events.api_requests.start_mission.response.put(
+        MissionStartResponse(
+            mission_started=False,
+            mission_not_started_reason="Failed to initialize robot",
+        )
+    )
     state_machine._finalize()

--- a/src/robot_interface/robot_interface.py
+++ b/src/robot_interface/robot_interface.py
@@ -244,3 +244,30 @@ class RobotInterface(metaclass=ABCMeta):
 
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def get_battery_level(self) -> float:
+        """
+        Method which returns the percent charge remaining in the robot battery.
+
+        Returns
+        -------
+        float
+            The battery percentage on the robot
+
+        Raises
+        -------
+        RobotCommunicationException
+            Raised if the robot package is unable to communicate with the robot API.
+            The fetching of robot battery level will be attempted again until success
+        RobotAPIException
+            Raised if the robot package is able to communicate with the API but an error
+            occurred while interpreting the response. The fetching of robot battery level
+            will be attempted again until success
+        RobotException
+            Catches other RobotExceptions that may have occurred while retrieving the
+            robot battery level. The fetching of robot battery level will
+            be attempted again until success
+
+        """
+        raise NotImplementedError

--- a/tests/test_double/robot_interface.py
+++ b/tests/test_double/robot_interface.py
@@ -85,6 +85,9 @@ class StubRobot(RobotInterface):
     def robot_status(self) -> RobotStatus:
         return self.robot_status_return_value
 
+    def get_battery_level(self):
+        return 80.0
+
 
 def stub_image_metadata() -> ImageMetadata:
     return ImageMetadata(


### PR DESCRIPTION
ISAR implementations will need to create a function which returns the battery level. Here is the relevant PR for ISAR robot: https://github.com/equinor/isar-robot/pull/256

Another change that had to be made for this PR is handling so that if we receive two requests that try to do the same thing at the same time, then the subsequent requests will return a 408 conflict, eg if we try to start two missions, or pause missions twice.

This PR includes example of event handler tests, but does not test all of them https://github.com/equinor/isar/issues/889.

After this is merged I will also move the business logic which decides if a robot is ready to start missions again, into ISAR. While the robot is recharging and not able to take in new missions, it will be in a "recharging" state. When it reaches its mission starting threshold it will then enter "home" and be able to accept missions again. In the event handler which handles the return home mission completing in the returning home state we will check the battery level. If the battery level is less that the mission starting threshold we will enter "recharging" state, otherwise we will enter "home" state. Nice and simple.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.