### PR TITLE
Change queue timeout back to 10

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     REQUEST_TIMEOUT: int = Field(default=30)
 
     # Timeout in seconds for checking whether there is a message on a queue
-    QUEUE_TIMEOUT: int = Field(default=3)
+    QUEUE_TIMEOUT: int = Field(default=10)
 
     # Sleep time for while loops in the finite state machine in seconds
     # The sleep is used to throttle the system on every iteration in the loop


### PR DESCRIPTION
I changed it to 3 seconds earlier to give a better response time for Flotilla, but it seems isar-robot and other instances are not consistently able to confirm that a mission has been stopped in that time.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.