### PR TITLE
Add spans on high level functions called by endpoints

### DIFF
--- a/src/isar/apis/robot_control/robot_controller.py
+++ b/src/isar/apis/robot_control/robot_controller.py
@@ -1,11 +1,14 @@
 import logging
 
 from fastapi import HTTPException
+from opentelemetry import trace
 
 from isar.apis.models.models import RobotInfoResponse
 from isar.config.settings import robot_settings, settings
 from isar.services.utilities.robot_utilities import RobotUtilities
 from robot_interface.models.robots.media import MediaConfig
+
+tracer = trace.get_tracer(__name__)
 
 
 class RobotController:
@@ -16,6 +19,7 @@ class RobotController:
         self.robot_utilities: RobotUtilities = robot_utilities
         self.logger = logging.getLogger("api")
 
+    @tracer.start_as_current_span("generate_media_config")
     def generate_media_config(self) -> MediaConfig:
         media_config: MediaConfig = self.robot_utilities.generate_media_config()
         if media_config is None:
@@ -25,6 +29,7 @@ class RobotController:
             )
         return media_config
 
+    @tracer.start_as_current_span("get_info")
     def get_info(self) -> RobotInfoResponse:
         return RobotInfoResponse(
             robot_package=settings.ROBOT_PACKAGE,

--- a/src/isar/apis/schedule/scheduling_controller.py
+++ b/src/isar/apis/schedule/scheduling_controller.py
@@ -2,6 +2,7 @@ import logging
 from http import HTTPStatus
 
 from fastapi import Body, HTTPException, Path
+from opentelemetry import trace
 
 from isar.apis.models.models import (
     ControlMissionResponse,
@@ -20,6 +21,8 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.task import TASKS, InspectionTask, MoveArm
 
+tracer = trace.get_tracer(__name__)
+
 
 class SchedulingController:
     def __init__(
@@ -29,6 +32,7 @@ class SchedulingController:
         self.scheduling_utilities: SchedulingUtilities = scheduling_utilities
         self.logger = logging.getLogger("api")
 
+    @tracer.start_as_current_span("start_mission_by_id")
     def start_mission_by_id(
         self,
         mission_id: str = Path(
@@ -54,6 +58,7 @@ class SchedulingController:
 
         return self._api_response(mission)
 
+    @tracer.start_as_current_span("start_mission")
     def start_mission(
         self,
         mission_definition: StartMissionDefinition = Body(
@@ -98,6 +103,7 @@ class SchedulingController:
         self.scheduling_utilities.start_mission(mission=mission)
         return self._api_response(mission)
 
+    @tracer.start_as_current_span("return_home")
     def return_home(self) -> None:
         self.logger.info("Received request to return home")
 
@@ -108,6 +114,7 @@ class SchedulingController:
 
         self.scheduling_utilities.return_home()
 
+    @tracer.start_as_current_span("pause_mission")
     def pause_mission(self) -> ControlMissionResponse:
         self.logger.info("Received request to pause current mission")
 
@@ -131,6 +138,7 @@ class SchedulingController:
         )
         return pause_mission_response
 
+    @tracer.start_as_current_span("resume_mission")
     def resume_mission(self) -> ControlMissionResponse:
         self.logger.info("Received request to resume current mission")
 
@@ -148,6 +156,7 @@ class SchedulingController:
         )
         return resume_mission_response
 
+    @tracer.start_as_current_span("stop_mission")
     def stop_mission(
         self,
         mission_id: StopMissionDefinition = Body(
@@ -181,6 +190,7 @@ class SchedulingController:
         )
         return stop_mission_response
 
+    @tracer.start_as_current_span("start_move_arm_mission")
     def start_move_arm_mission(
         self,
         arm_pose_literal: str = Path(
@@ -227,6 +237,7 @@ class SchedulingController:
         self.scheduling_utilities.start_mission(mission=mission)
         return self._api_response(mission)
 
+    @tracer.start_as_current_span("release_intervention_needed")
     def release_intervention_needed(self) -> None:
         self.logger.info("Received request to release intervention needed state")
 


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.

Add manual spans on high level functions. Example below where pause function appears as its own span in aspire dashboard.

<img width="1650" height="1018" alt="image" src="https://github.com/user-attachments/assets/bd98dd9c-3471-4032-b324-b1f558074c83" />

