### PR TITLE
Setting default blob storage account to empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Enabling API authentication also requires the same environment variables. The re
 AZURE_CLIENT_ID
 AZURE_TENANT_ID
 AZURE_CLIENT_SECRET
+ISAR_BLOB_STORAGE_ACCOUNT
 ```
 
 ## MQTT communication

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -168,7 +168,7 @@ class Settings(BaseSettings):
     UPLOAD_INSPECTIONS_ASYNC: bool = Field(default=False)
 
     # URL to storage account for Azure Blob Storage
-    BLOB_STORAGE_ACCOUNT: str = Field(default="eqrobotdevstorage")
+    BLOB_STORAGE_ACCOUNT: str = Field(default="")
 
     # Name of blob container in Azure Blob Storage [slimm test]
     BLOB_CONTAINER: str = Field(default="test")


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.