### PR TITLE
Avoid assumption of home on isar restart

### DIFF
--- a/src/isar/state_machine/transitions/functions/robot_status.py
+++ b/src/isar/state_machine/transitions/functions/robot_status.py
@@ -11,6 +11,11 @@ def is_offline(state_machine: "StateMachine") -> bool:
     return robot_status == RobotStatus.Offline
 
 
+def is_available(state_machine: "StateMachine") -> bool:
+    robot_status = state_machine.shared_state.robot_status.check()
+    return robot_status == RobotStatus.Available
+
+
 def is_available_or_home(state_machine: "StateMachine") -> bool:
     robot_status = state_machine.shared_state.robot_status.check()
     return robot_status == RobotStatus.Available or robot_status == RobotStatus.Home

--- a/src/isar/state_machine/transitions/robot_status.py
+++ b/src/isar/state_machine/transitions/robot_status.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, List
 
 from isar.state_machine.transitions.functions.robot_status import (
+    is_available,
     is_available_or_home,
     is_blocked_protective_stop,
     is_offline,
@@ -13,6 +14,14 @@ if TYPE_CHECKING:
 
 def get_robot_status_transitions(state_machine: "StateMachine") -> List[dict]:
     robot_status_transitions: List[dict] = [
+        {
+            "trigger": "robot_status_changed",
+            "source": [
+                state_machine.unknown_status_state,
+            ],
+            "dest": state_machine.await_next_mission_state,
+            "conditions": def_transition(state_machine, is_available),
+        },
         {
             "trigger": "robot_status_changed",
             "source": [

--- a/tests/isar/state_machine/test_state_machine.py
+++ b/tests/isar/state_machine/test_state_machine.py
@@ -128,7 +128,7 @@ def test_state_machine_transitions_when_running_full_mission(
     assert state_machine_thread.state_machine.transitions_list == deque(
         [
             States.UnknownStatus,
-            States.Home,
+            States.AwaitNextMission,
             States.Monitor,
             States.AwaitNextMission,
             States.ReturningHome,
@@ -341,7 +341,7 @@ def test_state_machine_failed_dependency(
     assert state_machine_thread.state_machine.transitions_list == deque(
         [
             States.UnknownStatus,
-            States.Home,
+            States.AwaitNextMission,
             States.Monitor,
             States.AwaitNextMission,
             States.ReturningHome,
@@ -523,7 +523,7 @@ def test_state_machine_with_unsuccessful_mission_stop_with_mission_id(
     assert state_machine_thread.state_machine.transitions_list == deque(
         [
             States.UnknownStatus,
-            States.Home,
+            States.AwaitNextMission,
             States.Monitor,
         ]
     )
@@ -559,7 +559,7 @@ def test_state_machine_with_unsuccessful_mission_stop(
     assert state_machine_thread.state_machine.transitions_list == deque(
         [
             States.UnknownStatus,
-            States.Home,
+            States.AwaitNextMission,
             States.Monitor,
             States.Stopping,
             States.Monitor,


### PR DESCRIPTION
This will make it possible for the initial state to become available instead of always becoming home on isar restart. It doesn't solve the issues that occur if isar restarts during monitor state, but ending up in intervention needed is better than a falls home-state

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.