### PR TITLE
Fix wrong syntax in error logging

### DIFF
--- a/src/isar/robot/robot_monitor_mission.py
+++ b/src/isar/robot/robot_monitor_mission.py
@@ -320,7 +320,8 @@ class RobotMonitorMissionThread(Thread):
                     new_task_status = self._get_task_status(current_task.id)
                 except RobotTaskStatusException as e:
                     self.logger.error(
-                        "Failed to collect task status", e.error_description
+                        "Failed to collect task status. Error description: %s",
+                        e.error_description,
                     )
                     break
                 except Exception:


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.