### PR TITLE
Reintroduce wrongly removed settings variable

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -236,6 +236,9 @@ class Settings(BaseSettings):
     # In general logging is configured in logging.conf
     LOG_HANDLER_LOCAL_ENABLED: bool = Field(default=True)
     LOG_HANDLER_APPLICATION_INSIGHTS_ENABLED: bool = Field(default=False)
+
+    DEBUG_LOG_FORMATTER: bool = Field(default=False)
+
     # You can set logger levels from environment variables ending with _LOG_LEVEL
     # For example, MQTT_LOG_LEVEL="DEBUG" will set the logger MQTT_LOGGER to DEBUG level
     # Handeled in log.py and only work for loggers defined in logging.conf


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.