### PR TITLE
Ensure we recheck robot status in unknown state

### DIFF
--- a/src/isar/state_machine/states/unknown_status.py
+++ b/src/isar/state_machine/states/unknown_status.py
@@ -43,6 +43,10 @@ class UnknownStatus(EventHandlerBase):
                 return state_machine.robot_status_blocked_protective_stop  # type: ignore
             return None
 
+        def _reset_status_check():
+            # Ensures that we will check the status immediately instead of waiting for it to change
+            self.events.robot_service_events.robot_status_changed.trigger_event(True)
+
         event_handlers: List[EventHandlerMapping] = [
             EventHandlerMapping(
                 name="stop_mission_event",
@@ -64,4 +68,5 @@ class UnknownStatus(EventHandlerBase):
             state_name="unknown_status",
             state_machine=state_machine,
             event_handler_mappings=event_handlers,
+            on_entry=_reset_status_check,
         )


### PR DESCRIPTION
This PR ensures that in unknown status we don't wait for the robot status to change but instead immediately check the current status anyways. This is relevant if we enter this state from intervention needed, since the robot status has not necessarily changed in this case. We might be in intervention needed while still having robot status available.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.