### PR TITLE
Use locking for API requests

### DIFF
--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -1,5 +1,6 @@
 from collections import deque
 from queue import Empty, Queue
+from threading import Lock
 from typing import Generic, Optional, Tuple, TypeVar
 
 from transitions import State
@@ -94,6 +95,7 @@ class APIEvent(Generic[T1, T2]):
     def __init__(self, name: str):
         self.request: Event[T1] = Event("api-" + name + "-request")
         self.response: Event[T2] = Event("api-" + name + "-request")
+        self.lock: Lock = Lock()
 
 
 class APIRequests:

--- a/src/isar/services/utilities/scheduling_utilities.py
+++ b/src/isar/services/utilities/scheduling_utilities.py
@@ -505,10 +505,23 @@ class SchedulingUtilities:
             )
 
     def _send_command(self, input: T1, api_event: APIEvent[T1, T2]) -> T2:
-        if api_event.request.has_event():
+        if api_event.lock.acquire(blocking=False):
             raise EventConflictError("API event has already been sent")
 
         try:
+            if api_event.request.has_event():
+                self.logger.error(
+                    "API request already had pending request before sending request"
+                )
+
+            if api_event.response.has_event():
+                self.logger.error(
+                    "API request already had response before sending request"
+                )
+
+            api_event.request.clear_event()
+            api_event.response.clear_event()
+
             api_event.request.trigger_event(input, timeout=1)
             return api_event.response.consume_event(timeout=self.queue_timeout)
         except EventTimeoutError as e:
@@ -519,3 +532,4 @@ class SchedulingUtilities:
         finally:
             api_event.request.clear_event()
             api_event.response.clear_event()
+            api_event.lock.release()


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.