### PR TITLE
Handle that robot can auto pause a mission

### DIFF
--- a/src/isar/state_machine/transitions/robot_status.py
+++ b/src/isar/state_machine/transitions/robot_status.py
@@ -79,6 +79,16 @@ def get_robot_status_transitions(state_machine: "StateMachine") -> List[dict]:
             "dest": state_machine.stopping_state,
         },
         {
+            "trigger": "robot_status_paused",
+            "source": state_machine.monitor_state,
+            "dest": state_machine.paused_state,
+        },
+        {
+            "trigger": "robot_status_paused",
+            "source": state_machine.returning_home_state,
+            "dest": state_machine.return_home_paused_state,
+        },
+        {
             "trigger": "robot_recharged",
             "source": state_machine.recharging_state,
             "dest": state_machine.home_state,


### PR DESCRIPTION
NB: This only handles auto-pausing if it occurs during monitor or returning home. If auto-pausing occur during goingToRecharge or goingToLockdown, it wont be possible to resume as these states dont have a corresponding version of paused. Could be implemented, but as this is a workaround that can most likely be removed after some months, it might not be worth the effort.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.