### PR TITLE
Keep mission ID until exiting mission state

### DIFF
--- a/src/isar/robot/robot.py
+++ b/src/isar/robot/robot.py
@@ -126,7 +126,6 @@ class Robot(object):
             self.signal_mission_stopped.clear()
             self.monitor_mission_thread = RobotMonitorMissionThread(
                 self.robot_service_events,
-                self.shared_state,
                 self.robot,
                 self.mqtt_publisher,
                 self.signal_thread_quitting,
@@ -194,6 +193,7 @@ class Robot(object):
                 self.start_mission_thread.join()
 
             start_mission.status = MissionStatus.NotStarted
+            self.shared_state.mission_id.trigger_event(start_mission.id)
             publish_mission_status(self.mqtt_publisher, start_mission)
             self.start_mission_thread = RobotStartMissionThread(
                 self.robot,

--- a/src/isar/robot/robot_monitor_mission.py
+++ b/src/isar/robot/robot_monitor_mission.py
@@ -4,7 +4,7 @@ from threading import Event, Thread
 from typing import Iterator, Optional
 
 from isar.config.settings import settings
-from isar.models.events import RobotServiceEvents, SharedState
+from isar.models.events import RobotServiceEvents
 from isar.services.utilities.mqtt_utilities import (
     publish_mission_status,
     publish_task_status,
@@ -54,7 +54,6 @@ class RobotMonitorMissionThread(Thread):
     def __init__(
         self,
         robot_service_events: RobotServiceEvents,
-        shared_state: SharedState,
         robot: RobotInterface,
         mqtt_publisher: MqttClientInterface,
         signal_thread_quitting: Event,
@@ -68,8 +67,6 @@ class RobotMonitorMissionThread(Thread):
         self.signal_mission_stopped: Event = signal_mission_stopped
         self.mqtt_publisher = mqtt_publisher
         self.current_mission: Optional[Mission] = mission
-        self.shared_state: SharedState = shared_state
-        self.shared_state.mission_id.trigger_event(mission.id)
 
         Thread.__init__(self, name="Robot mission monitoring thread")
 
@@ -339,7 +336,6 @@ class RobotMonitorMissionThread(Thread):
                 break
 
             time.sleep(settings.FSM_SLEEP_TIME)
-        self.shared_state.mission_id.trigger_event(None)
 
         mission_stopped = self.signal_mission_stopped.wait(0)
 

--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -74,6 +74,7 @@ class Monitor(EventHandlerBase):
                         f"Mission completed with status {mission_status}"
                     )
                     state_machine.print_transitions()
+                    shared_state.mission_id.clear_event()
                     return state_machine.mission_finished  # type: ignore
             return None
 
@@ -100,6 +101,7 @@ class Monitor(EventHandlerBase):
                 f"Failed to initiate mission because: "
                 f"{mission_failed.error_description}"
             )
+            state_machine.shared_state.mission_id.clear_event()
             return state_machine.mission_failed_to_start  # type: ignore
 
         event_handlers: List[EventHandlerMapping] = [

--- a/src/isar/state_machine/states/stopping.py
+++ b/src/isar/state_machine/states/stopping.py
@@ -38,6 +38,7 @@ class Stopping(EventHandlerBase):
             )
 
             state_machine.print_transitions()
+            state_machine.shared_state.mission_id.clear_event()
             if not state_machine.battery_level_is_above_mission_start_threshold():
                 state_machine.start_return_home_mission()
                 return state_machine.start_return_home_monitoring  # type: ignore

--- a/src/isar/state_machine/states/stopping_go_to_lockdown.py
+++ b/src/isar/state_machine/states/stopping_go_to_lockdown.py
@@ -39,6 +39,7 @@ class StoppingGoToLockdown(EventHandlerBase):
                 LockdownResponse(lockdown_started=True)
             )
             state_machine.start_return_home_mission()
+            state_machine.shared_state.mission_id.clear_event()
             return state_machine.start_lockdown_mission_monitoring  # type: ignore
 
         event_handlers: List[EventHandlerMapping] = [

--- a/src/isar/state_machine/states/stopping_go_to_recharge.py
+++ b/src/isar/state_machine/states/stopping_go_to_recharge.py
@@ -30,6 +30,7 @@ class StoppingGoToRecharge(EventHandlerBase):
                 "Robot battery too low to continue mission", True
             )
             state_machine.start_return_home_mission()
+            state_machine.shared_state.mission_id.clear_event()
             return state_machine.start_recharging_mission_monitoring  # type: ignore
 
         event_handlers: List[EventHandlerMapping] = [

--- a/tests/isar/services/robot/test_robot_service.py
+++ b/tests/isar/services/robot/test_robot_service.py
@@ -85,7 +85,6 @@ def test_mission_fails_to_stop(mocked_robot_service: Robot, mocker) -> None:
 
     r_service.monitor_mission_thread = RobotMonitorMissionThread(
         r_service.robot_service_events,
-        r_service.shared_state,
         r_service.robot,
         r_service.mqtt_publisher,
         r_service.signal_thread_quitting,
@@ -137,7 +136,6 @@ def test_stop_mission_waits_for_monitor_mission(
 
     r_service.monitor_mission_thread = RobotMonitorMissionThread(
         r_service.robot_service_events,
-        r_service.shared_state,
         r_service.robot,
         r_service.mqtt_publisher,
         r_service.signal_thread_quitting,


### PR DESCRIPTION
Before we were resetting the mission ID once the mission completed, but this could create timing problems when some stopping states were using the mission ID in their aborted mission MQTT messages. Ideally mission ID would be a state argument (so that it would not be a global state, and we could enforce that it is set before entering a state), but this is not supported in the transitions library.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.