### PR TITLE
Use success or fail instead of missionStatus in events

### DIFF
--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -12,7 +12,7 @@ from isar.apis.models.models import (
 from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
 from robot_interface.models.mission.mission import Mission
-from robot_interface.models.mission.status import MissionStatus, RobotStatus
+from robot_interface.models.mission.status import RobotStatus
 from robot_interface.models.mission.task import TASKS
 
 T = TypeVar("T")
@@ -141,9 +141,8 @@ class StateMachineEvents:
 
 class RobotServiceEvents:
     def __init__(self) -> None:
-        self.mission_status_updated: Event[MissionStatus] = Event(
-            "mission_status_updated"
-        )
+        self.mission_succeeded: Event[EmptyMessage] = Event("mission_succeeded")
+        self.mission_started: Event[EmptyMessage] = Event("mission_started")
         self.mission_failed: Event[ErrorMessage] = Event("mission_failed")
         self.robot_status_changed: Event[EmptyMessage] = Event("robot_status_changed")
         self.mission_failed_to_stop: Event[ErrorMessage] = Event(

--- a/src/isar/robot/robot.py
+++ b/src/isar/robot/robot.py
@@ -160,7 +160,8 @@ class Robot(object):
 
                 self.stop_mission_thread = None
                 # The mission status will already be reported on MQTT, the state machine does not need the event
-                self.robot_service_events.mission_status_updated.clear_event()
+                self.robot_service_events.mission_succeeded.clear_event()
+                self.robot_service_events.mission_failed.clear_event()
                 self.robot_service_events.mission_successfully_stopped.trigger_event(
                     EmptyMessage()
                 )

--- a/tests/isar/services/robot/test_robot_service.py
+++ b/tests/isar/services/robot/test_robot_service.py
@@ -169,7 +169,8 @@ def test_stop_mission_waits_for_monitor_mission(
     assert mission_successfully_stopped_event
 
     assert not r_service.robot_service_events.mission_failed_to_stop.has_event()
-    assert not r_service.robot_service_events.mission_status_updated.has_event()
+    assert not r_service.robot_service_events.mission_failed.has_event()
+    assert not r_service.robot_service_events.mission_succeeded.has_event()
 
     assert r_service.signal_mission_stopped.is_set()
     mock_join_monitor_thread.assert_called_once()
@@ -190,7 +191,8 @@ def test_mission_succeeds_to_stop(
     assert not r_service.robot_service_events.mission_failed_to_stop.has_event()
     assert r_service.robot_service_events.mission_successfully_stopped.has_event()
 
-    assert not r_service.robot_service_events.mission_status_updated.has_event()
+    assert not r_service.robot_service_events.mission_succeeded.has_event()
+    assert not r_service.robot_service_events.mission_failed.has_event()
 
     assert r_service.monitor_mission_thread is None
 

--- a/tests/isar/state_machine/states/test_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_lockdown_state.py
@@ -7,7 +7,6 @@ from isar.state_machine.states.going_to_lockdown import GoingToLockdown
 from isar.state_machine.states.lockdown import Lockdown
 from isar.state_machine.states.monitor import Monitor
 from isar.state_machine.states.stopping_go_to_lockdown import StoppingGoToLockdown
-from robot_interface.models.mission.status import MissionStatus
 
 
 def test_mission_stopped_when_going_to_lockdown(
@@ -37,12 +36,12 @@ def test_going_to_lockdown_transitions_to_lockdown(
 
     going_to_lockdown_state: State = cast(State, sync_state_machine.current_state)
     event_handler: Optional[EventHandlerMapping] = (
-        going_to_lockdown_state.get_event_handler_by_name("mission_status_event")
+        going_to_lockdown_state.get_event_handler_by_name("mission_succeeded_event")
     )
 
     assert event_handler is not None
 
-    transition = event_handler.handler(MissionStatus.Successful)
+    transition = event_handler.handler(EmptyMessage())
 
     sync_state_machine.current_state = transition(sync_state_machine)
     assert type(sync_state_machine.current_state) is Lockdown

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -7,7 +7,6 @@ from isar.state_machine.states.going_to_recharging import GoingToRecharging
 from isar.state_machine.states.home import Home
 from isar.state_machine.states.lockdown import Lockdown
 from isar.state_machine.states.recharging import Recharging
-from robot_interface.models.mission.status import MissionStatus
 
 
 def test_going_to_recharging_goes_to_recharge(
@@ -16,12 +15,12 @@ def test_going_to_recharging_goes_to_recharge(
     sync_state_machine.current_state = GoingToRecharging(sync_state_machine)
     going_to_recharging_state: State = cast(State, sync_state_machine.current_state)
     event_handler: Optional[EventHandlerMapping] = (
-        going_to_recharging_state.get_event_handler_by_name("mission_status_event")
+        going_to_recharging_state.get_event_handler_by_name("mission_succeeded_event")
     )
 
     assert event_handler is not None
 
-    transition = event_handler.handler(MissionStatus.Successful)
+    transition = event_handler.handler(EmptyMessage())
 
     sync_state_machine.current_state = transition(sync_state_machine)
     assert type(sync_state_machine.current_state) is Recharging

--- a/tests/isar/state_machine/states/test_returning_home_state.py
+++ b/tests/isar/state_machine/states/test_returning_home_state.py
@@ -16,7 +16,6 @@ from isar.state_machine.states.returning_home import ReturningHome
 from isar.state_machine.states.stopping_return_home import StoppingReturnHome
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 from robot_interface.models.mission.mission import Mission
-from robot_interface.models.mission.status import MissionStatus
 from robot_interface.models.mission.task import ReturnToHome
 
 
@@ -91,12 +90,12 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
 
     returning_home_state: State = cast(State, sync_state_machine.current_state)
     event_handler: Optional[EventHandlerMapping] = (
-        returning_home_state.get_event_handler_by_name("mission_status_event")
+        returning_home_state.get_event_handler_by_name("mission_succeeded_event")
     )
 
     assert event_handler is not None
 
-    transition = event_handler.handler(MissionStatus.Successful)
+    transition = event_handler.handler(EmptyMessage())
 
     sync_state_machine.current_state = transition(sync_state_machine)
     assert type(sync_state_machine.current_state) is Home

--- a/tests/isar/state_machine/test_integration_test_for_states.py
+++ b/tests/isar/state_machine/test_integration_test_for_states.py
@@ -13,7 +13,7 @@ from isar.services.utilities.scheduling_utilities import SchedulingUtilities
 from isar.state_machine.states_enum import States
 from isar.storage.storage_interface import StorageInterface
 from robot_interface.models.mission.mission import Mission
-from robot_interface.models.mission.status import MissionStatus, RobotStatus
+from robot_interface.models.mission.status import MissionStatus, RobotStatus, TaskStatus
 from robot_interface.models.mission.task import TakeImage, Task
 from tests.test_mocks.pose import DummyPose
 from tests.test_mocks.robot_interface import (
@@ -84,6 +84,7 @@ def test_state_machine_failed_dependency(
     mocker: MockerFixture,
 ) -> None:
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
+    mocker.patch.object(settings, "RETURN_HOME_RETRY_LIMIT", 3)
 
     task_1: Task = TakeImage(
         target=DummyPose.default_pose().position, robot_pose=DummyPose.default_pose()
@@ -93,6 +94,7 @@ def test_state_machine_failed_dependency(
     )
     mission: Mission = Mission(name="Dummy misson", tasks=[task_1, task_2])
 
+    mocker.patch.object(StubRobot, "task_status", return_value=TaskStatus.Failed)
     mocker.patch.object(StubRobot, "mission_status", return_value=MissionStatus.Failed)
 
     state_machine_thread.start()


### PR DESCRIPTION
This kind of thing:
<img width="1126" height="566" alt="image" src="https://github.com/user-attachments/assets/c0c35485-b306-4ba2-8289-58a2e82346f7" />

No point reporting to the state machine that mission status is InProgress or NotStarted, since that is not relevant. And no need to have two different events for mission failure.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.