### PR TITLE
Refactor robot_monitor_mission.py

### DIFF
--- a/src/isar/services/utilities/mqtt_utilities.py
+++ b/src/isar/services/utilities/mqtt_utilities.py
@@ -6,7 +6,7 @@ from isar.config.settings import settings
 from isar.models.status import IsarStatus
 from isar.services.service_connections.mqtt.mqtt_client import props_expiry
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
-from robot_interface.models.mission.mission import Mission
+from robot_interface.models.mission.status import MissionStatus
 from robot_interface.models.mission.task import TASKS
 from robot_interface.telemetry.mqtt_client import MqttClientInterface
 from robot_interface.telemetry.payloads import (
@@ -18,7 +18,7 @@ from robot_interface.utilities.json_service import EnhancedJSONEncoder
 
 
 def publish_task_status(
-    mqtt_publisher: MqttClientInterface, task: TASKS, mission: Optional[Mission]
+    mqtt_publisher: MqttClientInterface, task: TASKS, mission_id: Optional[str]
 ) -> None:
     """Publishes the task status to the MQTT Broker"""
 
@@ -30,7 +30,7 @@ def publish_task_status(
     payload: TaskPayload = TaskPayload(
         isar_id=settings.ISAR_ID,
         robot_name=settings.ROBOT_NAME,
-        mission_id=mission.id if mission else None,
+        mission_id=mission_id,
         task_id=task.id if task else None,
         status=task.status if task else None,
         task_type=task.type if task else None,
@@ -49,25 +49,26 @@ def publish_task_status(
 
 
 def publish_mission_status(
-    mqtt_publisher: MqttClientInterface, mission: Mission
+    mqtt_publisher: MqttClientInterface,
+    mission_id: str,
+    mission_status: MissionStatus,
+    error_message: Optional[ErrorMessage],
 ) -> None:
     if not mqtt_publisher:
         return
 
-    error_message = mission.error_message
-
     payload: MissionPayload = MissionPayload(
         isar_id=settings.ISAR_ID,
         robot_name=settings.ROBOT_NAME,
-        mission_id=mission.id,
-        status=mission.status,
+        mission_id=mission_id,
+        status=mission_status,
         error_reason=error_message.error_reason if error_message else None,
         error_description=(error_message.error_description if error_message else None),
         timestamp=datetime.now(timezone.utc),
     )
 
     mqtt_publisher.publish(
-        topic=settings.TOPIC_ISAR_MISSION + f"/{mission.id}",
+        topic=settings.TOPIC_ISAR_MISSION + f"/{mission_id}",
         payload=json.dumps(payload, cls=EnhancedJSONEncoder),
         qos=1,
         retain=True,


### PR DESCRIPTION
Closes #1062 

The main change is adding a couple new functions in the file to make the main function smaller. We also move the event reporting out from the robot_monitor_mission.py file into the robot.py file, so that we ensure that the thread has completed before reporting the results. Tasks are still added to the upload queue as soon as a task completes, but this is handled as a callback function.

More lines are added than deleted because I added more tests.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.