### PR TITLE
fix: log error description instead of error type for RobotException

### DIFF
--- a/src/robot_interface/models/exceptions/robot_exceptions.py
+++ b/src/robot_interface/models/exceptions/robot_exceptions.py
@@ -41,6 +41,9 @@ class RobotException(Exception):
         self.error_reason: ErrorReason = error_reason
         self.error_description: str = error_description
 
+    def __str__(self) -> str:
+        return self.error_description
+
 
 # An exception which should be thrown by the robot package if it is unable to
 # communicate with the robot API. ISAR will retry the request.


### PR DESCRIPTION
## Problem
When catching `RobotException` (or its subclasses) and logging with `f"{e}"`, Python's default `__str__` for exceptions returns the class name rather than a meaningful message, since `RobotException.__init__` doesn't call `super().__init__()`.

This results in log messages like:
```
Failed to retrieve robot status: RobotActionException
```
instead of the actual error description.

## Fix
Add a `__str__` method to the `RobotException` base class that returns `self.error_description`. This fixes all subclasses automatically.

Now the log will show:
```
Failed to retrieve robot status: <actual error description>
```

Closes #956