### PR TITLE
Fix: Transition to intervention_needed when battery-low stop fails

### DIFF
--- a/src/isar/state_machine/states/stopping_go_to_recharge.py
+++ b/src/isar/state_machine/states/stopping_go_to_recharge.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, List
 
 import isar.state_machine.states.going_to_recharging as GoingToRecharging
-import isar.state_machine.states.monitor as Monitor
+import isar.state_machine.states.intervention_needed as InterventionNeeded
 from isar.eventhandlers.eventhandler import EventHandlerMapping, State, Transition
 from isar.models.events import EmptyMessage
 from isar.state_machine.states_enum import States
@@ -18,8 +18,10 @@ class StoppingGoToRecharge(State):
 
         def _failed_stop_event_handler(
             error_message: ErrorMessage,
-        ) -> Transition[Monitor.Monitor]:
-            return Monitor.transition_with_existing_mission(mission_id)
+        ) -> Transition[InterventionNeeded.InterventionNeeded]:
+            return InterventionNeeded.transition(
+                "Failed to stop mission when battery was low"
+            )
 
         def _successful_stop_event_handler(
             successful_stop: EmptyMessage,

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -14,6 +14,7 @@ from isar.models.events import EmptyMessage
 from isar.modules import ApplicationContainer
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
 from isar.state_machine.state_machine import StateMachine
+from isar.state_machine.states.intervention_needed import InterventionNeeded
 from isar.state_machine.states.monitor import Monitor
 from isar.state_machine.states.pausing import Pausing
 from isar.state_machine.states.resuming import Resuming
@@ -47,7 +48,7 @@ def _mock_robot_exception_with_message() -> RobotException:
     )
 
 
-def test_stopping_to_recharge_goes_to_monitor(
+def test_stopping_to_recharge_goes_to_intervention_needed(
     sync_state_machine: StateMachine,
 ) -> None:
     sync_state_machine.current_state = StoppingGoToRecharge(
@@ -62,10 +63,10 @@ def test_stopping_to_recharge_goes_to_monitor(
 
     transition = event_handler.handler(EmptyMessage())
 
-    assert sync_state_machine.events.mqtt_queue.empty()
-
     sync_state_machine.current_state = transition(sync_state_machine)
-    assert type(sync_state_machine.current_state) is Monitor
+
+    assert not sync_state_machine.events.mqtt_queue.empty()
+    assert type(sync_state_machine.current_state) is InterventionNeeded
 
 
 def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(


### PR DESCRIPTION
Fixes #1112

## Problem
When the robot fails to stop a mission due to low battery, it currently transitions back to `monitor` state, creating an infinite retry loop.

## Solution
Changed the state transition to go to `intervention_needed` instead, which automatically sends an MQTT notification to operators.

## Changes
- Modified state transition logic in the state machine
- Failed stops during automated battery-low scenarios now transition to `intervention_needed`
- User-initiated stops still go to `monitor` for debugging purposes

## Testing
- Ran existing test suite
- Verified the state transition change works as expected

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.