### PR TITLE
test: reuse wait helper for async assertions

### DIFF
--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -1,4 +1,3 @@
-import time
 from collections import deque
 from typing import cast
 
@@ -27,6 +26,7 @@ from tests.test_mocks.state_machine_mocks import (
     UploaderThreadMock,
 )
 from tests.test_mocks.task import StubTask
+from tests.test_utils import wait_until
 
 
 def test_state_machine_with_successful_mission_stop(
@@ -56,13 +56,17 @@ def test_state_machine_with_successful_mission_stop(
     state_machine_thread.start()
     robot_service_thread.start()
     uploader_thread.start()
-    time.sleep(1)
+    assert wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == deque([States.UnknownStatus, States.Home])
+    )
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(0.5)
+    assert wait_until(
+        lambda: state_machine_thread.state_machine.current_state.name == States.Monitor
+    )
     scheduling_utilities.stop_mission(mission_id=mission.id)
-    time.sleep(3)  # Allow enough time to stop the mission
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.Home,
@@ -71,6 +75,11 @@ def test_state_machine_with_successful_mission_stop(
             States.AwaitNextMission,
         ]
     )
+    assert wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
+    )
+    assert state_machine_thread.state_machine.transitions_list == expected_transitions
 
 
 def test_transition_from_resuming_to_paused(

--- a/tests/isar/state_machine/states/test_blocked_protective_stop_state.py
+++ b/tests/isar/state_machine/states/test_blocked_protective_stop_state.py
@@ -1,4 +1,3 @@
-import time
 from collections import deque
 
 from pytest_mock import MockerFixture
@@ -10,6 +9,7 @@ from tests.test_mocks.state_machine_mocks import (
     RobotServiceThreadMock,
     StateMachineThreadMock,
 )
+from tests.test_utils import wait_until
 
 
 def test_state_machine_idle_to_blocked_protective_stop_to_idle(
@@ -29,8 +29,12 @@ def test_state_machine_idle_to_blocked_protective_stop_to_idle(
 
     state_machine_thread.start()
     robot_service_thread.start()
-    time.sleep(5)
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [States.UnknownStatus, States.BlockedProtectiveStop, States.Home]
     )
+    assert wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
+    )
+    assert state_machine_thread.state_machine.transitions_list == expected_transitions

--- a/tests/isar/storage/test_uploader.py
+++ b/tests/isar/storage/test_uploader.py
@@ -17,6 +17,7 @@ from robot_interface.models.mission.task import TakeImage
 from tests.test_mocks.blob_storage import StorageEmptyBlobPathsFake, StorageFake
 from tests.test_mocks.mqtt_client import MqttPublisherFake
 from tests.test_mocks.state_machine_mocks import UploaderThreadMock
+from tests.test_utils import wait_until
 
 MISSION_ID = "some-mission-id"
 ARBITRARY_IMAGE_METADATA = ImageMetadata(
@@ -67,9 +68,9 @@ def test_should_upload_from_queue(
     uploader: Uploader = container.uploader()
 
     uploader.upload_queue.put(message)
-    time.sleep(0.01)
 
     storage_handler: StorageFake = uploader.storage_handlers[0]  # type: ignore
+    assert wait_until(lambda: inspection in storage_handler.stored_inspections)
     assert inspection in storage_handler.stored_inspections
 
 
@@ -98,9 +99,9 @@ def test_should_retry_failed_upload_from_queue(
     # Should not upload, instead raise StorageException
     assert not storage_handler.blob_exists(inspection)
     storage_handler.will_fail = False
-    time.sleep(3)
 
     # After some time, it should have retried and now it should be successful
+    assert wait_until(lambda: storage_handler.blob_exists(inspection))
     assert storage_handler.blob_exists(inspection)
 
 
@@ -127,8 +128,8 @@ def test_should_not_publish_when_blob_paths_are_empty(
         mission,
     )
     uploader.upload_queue.put(message)
-    time.sleep(1)
 
+    assert wait_until(lambda: inspection in storage_handler.stored)
     assert inspection in storage_handler.stored
 
     assert len(mqtt_fake.published) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import time
+from collections.abc import Callable
+
+
+def wait_until(
+    condition: Callable[[], bool],
+    timeout: float = 5,
+    interval: float = 0.01,
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(interval)
+    return condition()


### PR DESCRIPTION
Fixes #1134

## Summary
- Add a shared test wait helper for polling asynchronous conditions.
- Replace selected fixed sleeps in uploader and state-machine tests with condition-based waits.
- Leave absence-check sleeps in place where the wait window is part of the assertion.

## Testing
- Syntax checked changed files with Pylance: no syntax errors.
- Targeted pytest command was attempted but blocked by an existing syntax error in src/robot_interface/telemetry/mqtt_client.py:113 under the local Python 3.11 environment.