### PR TITLE
Use federated credentials for Postgres auth

### DIFF
--- a/alembic/README
+++ b/alembic/README
@@ -3,7 +3,12 @@ Alembic is used to migrate the databases. [link](https://alembic.sqlalchemy.org/
 # How to
 
 Requirements:
-1. Set credentials for azure authentication towards the postgres database.
+1. Set credentials for Azure authentication towards the postgres database.
+   Credential types are controlled by `ISAR_ALLOWED_AUTH_METHODS`, a
+   comma-separated list of `WorkloadIdentity` (federated token in AKS) and/or
+   `ClientSecret` (reads `ISAR_AZURE_CLIENT_SECRET`). Order sets priority in
+   the resulting `ChainedTokenCredential`. Default is `ClientSecret`, which
+   `alembic env.py` uses locally.
 
 <details>
 <summary>

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -119,6 +119,12 @@ class Settings(BaseSettings):
         print("Using environment variable for AZURE_CLIENT_ID")
         AZURE_CLIENT_ID = os.environ[azure_client_id_name]
 
+    # Ordered, comma-separated list of credential types used to acquire an
+    # Entra-ID token for the Postgres connection. Allowed values:
+    # "WorkloadIdentity", "ClientSecret". Order sets priority in the resulting
+    # ChainedTokenCredential (e.g. "WorkloadIdentity,ClientSecret").
+    ALLOWED_AUTH_METHODS: str = Field(default="ClientSecret")
+
     # MQTT username
     # The username and password is set by the MQTT broker and must be known in advance
     # The password should be set as an environment variable "MQTT_PASSWORD"
@@ -238,6 +244,10 @@ class Settings(BaseSettings):
     @classmethod
     def prefix_isar_topics(cls, v: Any, info: ValidationInfo) -> str:
         return f"isar/{info.data['ISAR_ID']}/{v}"
+
+    @property
+    def allowed_auth_methods(self) -> List[str]:
+        return [m.strip() for m in self.ALLOWED_AUTH_METHODS.split(",") if m.strip()]
 
     model_config = SettingsConfigDict(
         env_prefix="ISAR_",

--- a/src/isar/services/service_connections/database_connection.py
+++ b/src/isar/services/service_connections/database_connection.py
@@ -1,31 +1,109 @@
+import logging
 import os
+from functools import lru_cache
 
-from azure.core.credentials import AccessToken
-from azure.identity import ClientSecretCredential
+from azure.core.credentials import AccessToken, TokenCredential
+from azure.identity import (
+    ChainedTokenCredential,
+    ClientSecretCredential,
+    WorkloadIdentityCredential,
+)
 
 from isar.config.settings import settings
 
+logger = logging.getLogger("api")
+
+# Default path where azure-workload-identity projects the SA token in AKS pods.
+_DEFAULT_FEDERATED_TOKEN_FILE = "/var/run/secrets/azure/tokens/azure-identity-token"
+
+_AZURE_POSTGRES_SCOPE = "https://ossrdbms-aad.database.windows.net/.default"
+
+
+@lru_cache(maxsize=1)
+def _get_credential() -> TokenCredential:
+    """Build a TokenCredential for Entra-ID auth against Postgres.
+
+    Credential types and priority are configured via
+    ``settings.allowed_auth_methods`` (``"WorkloadIdentity"`` and/or
+    ``"ClientSecret"``, case-insensitive).
+    """
+    token_file_path = os.environ.get(
+        "AZURE_FEDERATED_TOKEN_FILE", _DEFAULT_FEDERATED_TOKEN_FILE
+    )
+    client_secret = os.environ.get("ISAR_AZURE_CLIENT_SECRET")
+
+    credentials: list[TokenCredential] = []
+    activated: list[str] = []
+
+    for method in settings.allowed_auth_methods:
+        normalized = method.strip().lower()
+        if normalized == "workloadidentity":
+            if os.path.exists(token_file_path):
+                credentials.append(
+                    WorkloadIdentityCredential(
+                        tenant_id=settings.AZURE_TENANT_ID,
+                        client_id=settings.AZURE_CLIENT_ID,
+                        token_file_path=token_file_path,
+                    )
+                )
+                activated.append("WorkloadIdentityCredential")
+            else:
+                logger.warning(
+                    "ISAR_ALLOWED_AUTH_METHODS includes 'WorkloadIdentity' but "
+                    f"no federated token file found at '{token_file_path}'; "
+                    "skipping WorkloadIdentityCredential."
+                )
+        elif normalized == "clientsecret":
+            if client_secret and not client_secret.lower().startswith("fill in"):
+                credentials.append(
+                    ClientSecretCredential(
+                        tenant_id=settings.AZURE_TENANT_ID,
+                        client_id=settings.AZURE_CLIENT_ID,
+                        client_secret=client_secret,
+                    )
+                )
+                activated.append("ClientSecretCredential")
+            else:
+                logger.warning(
+                    "ISAR_ALLOWED_AUTH_METHODS includes 'ClientSecret' but "
+                    "ISAR_AZURE_CLIENT_SECRET is missing/placeholder; skipping "
+                    "ClientSecretCredential."
+                )
+        else:
+            logger.warning(
+                f"Unknown auth method '{method}' in ISAR_ALLOWED_AUTH_METHODS; "
+                "expected 'WorkloadIdentity' or 'ClientSecret'."
+            )
+
+    if not credentials:
+        raise RuntimeError(
+            "No usable Azure credential could be constructed from "
+            "ISAR_ALLOWED_AUTH_METHODS. Configure at least one of "
+            "'WorkloadIdentity' (with a federated token file present at "
+            f"'{token_file_path}') or 'ClientSecret' (with "
+            "ISAR_AZURE_CLIENT_SECRET set)."
+        )
+
+    if len(credentials) == 1:
+        logger.info(f"Database auth using {activated[0]} only")
+        return credentials[0]
+
+    logger.info("Database auth using ChainedTokenCredential: " + " -> ".join(activated))
+    return ChainedTokenCredential(*credentials)
+
 
 def get_access_token() -> AccessToken:
-    credential = ClientSecretCredential(
-        client_id=settings.AZURE_CLIENT_ID,
-        tenant_id=settings.AZURE_TENANT_ID,
-        client_secret=os.environ["ISAR_AZURE_CLIENT_SECRET"],
-    )
-    accesstoken = credential.get_token(
-        "https://ossrdbms-aad.database.windows.net/.default"
-    )
-    return accesstoken
+    credential = _get_credential()
+    return credential.get_token(_AZURE_POSTGRES_SCOPE)
 
 
 def get_db_connection_string() -> str:
-    token_env = get_access_token().token
-    password_env = token_env
+    token = get_access_token().token
 
     ssl_mode = "?sslmode=require"
 
     return (
         f"postgresql://"
-        f"{settings.DATABASE_USER}:{password_env}@"
+        f"{settings.DATABASE_USER}:{token}@"
         f"{settings.DATABASE_SERVER_NAME}:5432/isar{ssl_mode}"
     )

--- a/tests/isar/services/service_connections/test_database_connection.py
+++ b/tests/isar/services/service_connections/test_database_connection.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+
+import pytest
+from azure.identity import (
+    ChainedTokenCredential,
+    ClientSecretCredential,
+    WorkloadIdentityCredential,
+)
+from pytest_mock import MockerFixture
+
+from isar.services.service_connections import database_connection
+
+
+@pytest.fixture(autouse=True)
+def _clear_credential_cache() -> None:
+    database_connection._get_credential.cache_clear()
+
+
+def _set_methods(mocker: MockerFixture, methods: list[str]) -> None:
+    mocker.patch.object(
+        database_connection.settings, "ALLOWED_AUTH_METHODS", ",".join(methods)
+    )
+
+
+class TestGetCredential:
+    def test_workload_identity_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        token_file = tmp_path / "azure-identity-token"
+        token_file.write_text("dummy-token")
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", str(token_file))
+        monkeypatch.delenv("ISAR_AZURE_CLIENT_SECRET", raising=False)
+        _set_methods(mocker, ["WorkloadIdentity"])
+
+        credential = database_connection._get_credential()
+
+        assert isinstance(credential, WorkloadIdentityCredential)
+
+    def test_client_secret_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        monkeypatch.setenv(
+            "AZURE_FEDERATED_TOKEN_FILE", str(tmp_path / "does-not-exist")
+        )
+        monkeypatch.setenv("ISAR_AZURE_CLIENT_SECRET", "some-secret")
+        _set_methods(mocker, ["ClientSecret"])
+
+        credential = database_connection._get_credential()
+
+        assert isinstance(credential, ClientSecretCredential)
+
+    def test_chained_in_configured_order(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        token_file = tmp_path / "azure-identity-token"
+        token_file.write_text("dummy-token")
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", str(token_file))
+        monkeypatch.setenv("ISAR_AZURE_CLIENT_SECRET", "some-secret")
+        _set_methods(mocker, ["WorkloadIdentity", "ClientSecret"])
+
+        credential = database_connection._get_credential()
+
+        assert isinstance(credential, ChainedTokenCredential)
+        assert isinstance(credential.credentials[0], WorkloadIdentityCredential)
+        assert isinstance(credential.credentials[1], ClientSecretCredential)
+
+    def test_workload_identity_skipped_when_no_token_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        monkeypatch.setenv(
+            "AZURE_FEDERATED_TOKEN_FILE", str(tmp_path / "does-not-exist")
+        )
+        monkeypatch.setenv("ISAR_AZURE_CLIENT_SECRET", "some-secret")
+        _set_methods(mocker, ["WorkloadIdentity", "ClientSecret"])
+
+        credential = database_connection._get_credential()
+
+        assert isinstance(credential, ClientSecretCredential)
+
+    def test_client_secret_skipped_when_placeholder(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        token_file = tmp_path / "azure-identity-token"
+        token_file.write_text("dummy-token")
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", str(token_file))
+        monkeypatch.setenv("ISAR_AZURE_CLIENT_SECRET", "Fill in your secret here")
+        _set_methods(mocker, ["WorkloadIdentity", "ClientSecret"])
+
+        credential = database_connection._get_credential()
+
+        assert isinstance(credential, WorkloadIdentityCredential)
+
+    def test_raises_when_no_method_yields_a_credential(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        monkeypatch.setenv(
+            "AZURE_FEDERATED_TOKEN_FILE", str(tmp_path / "does-not-exist")
+        )
+        monkeypatch.delenv("ISAR_AZURE_CLIENT_SECRET", raising=False)
+        _set_methods(mocker, ["WorkloadIdentity", "ClientSecret"])
+
+        with pytest.raises(RuntimeError, match="No usable Azure credential"):
+            database_connection._get_credential()
+
+    def test_raises_when_allowed_methods_is_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        monkeypatch.setenv("ISAR_AZURE_CLIENT_SECRET", "some-secret")
+        _set_methods(mocker, [])
+
+        with pytest.raises(RuntimeError, match="No usable Azure credential"):
+            database_connection._get_credential()
+
+    def test_unknown_method_is_ignored(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        monkeypatch.setenv("ISAR_AZURE_CLIENT_SECRET", "some-secret")
+        _set_methods(mocker, ["NotARealMethod", "ClientSecret"])
+
+        credential = database_connection._get_credential()
+
+        assert isinstance(credential, ClientSecretCredential)
+
+
+class TestGetDbConnectionString:
+    def test_includes_user_server_token_and_ssl_mode(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        mocker.patch.object(database_connection.settings, "DATABASE_USER", "isar-app")
+        mocker.patch.object(
+            database_connection.settings,
+            "DATABASE_SERVER_NAME",
+            "robotics-dev-psql-server.postgres.database.azure.com",
+        )
+
+        # Replace the token acquisition path so the test does not reach Azure.
+        fake_token = mocker.MagicMock(token="ENTRA_TOKEN")
+        mocker.patch.object(
+            database_connection, "get_access_token", return_value=fake_token
+        )
+
+        url = database_connection.get_db_connection_string()
+
+        assert url == (
+            "postgresql://isar-app:ENTRA_TOKEN@"
+            "robotics-dev-psql-server.postgres.database.azure.com:5432/isar"
+            "?sslmode=require"
+        )


### PR DESCRIPTION
## Summary
- Switch the Postgres `TokenCredential` to `WorkloadIdentityCredential` when a federated token file is mounted in the pod, with `ClientSecretCredential` (via `ISAR_AZURE_CLIENT_SECRET`) as a fallback for local development.
- When both are available, they are combined in a `ChainedTokenCredential` so workload identity is tried first and the secret is a safety net.
- Cache the credential with `lru_cache` so the underlying Entra-ID access token is reused across callers (the same path is hit by `alembic env.py`).

## Why
Part of [equinor/robotics-infrastructure#910](https://github.com/equinor/robotics-infrastructure/issues/910): replace static client secrets with federated credentials for runtime application auth against Azure Database for PostgreSQL. The IaC change (service-account annotation / federated identity credential) and the CI/CD migration are tracked separately under #755 and #756 in `robotics-infrastructure`; this PR is the ISAR application-side change.

## How it works
- `_get_credential()` inspects `AZURE_FEDERATED_TOKEN_FILE` (default `/var/run/secrets/azure/tokens/azure-identity-token`).
  - If present → add `WorkloadIdentityCredential` with `tenant_id`/`client_id` from `settings`.
  - If `ISAR_AZURE_CLIENT_SECRET` is set (and not a `Fill in...` placeholder) → add `ClientSecretCredential`.
  - 0 → raise `RuntimeError` with a clear message.
  - 1 → return it directly.
  - 2 → return a `ChainedTokenCredential`.
- `get_access_token()` and `get_db_connection_string()` now delegate to the cached credential.

## Test plan
- New `tests/isar/services/service_connections/test_database_connection.py` covers all five `_get_credential` branches (workload-only, secret-only, chained, missing-both raises, `Fill in` placeholder ignored) and the URL assembly in `get_db_connection_string`.
- `pytest tests/` → all 160 tests pass locally.
- `mypy`, `ruff check`, `black --check`, `isort --check-only` all clean on modified files.

## Notes for reviewers
- `radixconfig.yml` still declares the `AZURE_CLIENT_SECRET` secret; leaving it intact lets the fallback continue to work through the rollout and avoids coupling this PR to the infrastructure change.
- The CI workflow exports `AZURE_CLIENT_SECRET` while this code reads `ISAR_AZURE_CLIENT_SECRET` – that pre-existing mismatch is left for the CI/CD migration (#756).

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.