### PR TITLE
Refactor thread sleep intervals slightly

### DIFF
--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -64,10 +64,9 @@ class Settings(BaseSettings):
 
     # ISAR telemetry intervals
     ROBOT_HEARTBEAT_PUBLISH_INTERVAL: float = Field(default=1)
-    ROBOT_INFO_PUBLISH_INTERVAL: float = Field(default=5)
+    ROBOT_INFO_PUBLISH_INTERVAL: float = Field(default=30)
     ROBOT_API_BATTERY_POLL_INTERVAL: float = Field(default=5)
     ROBOT_API_STATUS_POLL_INTERVAL: float = Field(default=5)
-    THREAD_CHECK_INTERVAL: float = Field(default=0.01)
 
     # Determines the minimum battery level the robot must have to start a mission
     # If it drops below this level it will recharge to the value set by

--- a/src/isar/robot/robot_battery.py
+++ b/src/isar/robot/robot_battery.py
@@ -26,34 +26,21 @@ class RobotBatteryThread(Thread):
     def stop(self) -> None:
         return
 
-    def _is_ready_to_poll_for_battery(self) -> bool:
-        if self.force_battery_poll_next_iteration:
-            self.force_battery_poll_next_iteration = False
-            return True
-
-        time_since_last_robot_battery_poll = (
-            time.time() - self.last_robot_battery_poll_time
-        )
-        return (
-            time_since_last_robot_battery_poll
-            > settings.ROBOT_API_BATTERY_POLL_INTERVAL
-        )
-
     def run(self) -> None:
         if self.signal_exit.is_set():
             return
 
-        thread_check_interval = settings.THREAD_CHECK_INTERVAL
+        while not self.signal_exit.wait(0):
 
-        while not self.signal_exit.wait(thread_check_interval):
-            if not self._is_ready_to_poll_for_battery():
-                continue
+            time.sleep(settings.ROBOT_API_BATTERY_POLL_INTERVAL)
+
             try:
                 self.last_robot_battery_poll_time = time.time()
 
                 robot_battery_level = self.robot.get_battery_level()
 
                 self.shared_state.robot_battery_level.update(robot_battery_level)
+
             except RobotException as e:
                 self.logger.error(f"Failed to retrieve robot battery level: {e}")
                 continue

--- a/src/isar/robot/robot_status.py
+++ b/src/isar/robot/robot_status.py
@@ -35,22 +35,13 @@ class RobotStatusThread(Thread):
     def stop(self) -> None:
         return
 
-    def _is_ready_to_poll_for_status(self) -> bool:
-        time_since_last_robot_status_poll = (
-            time.time() - self.last_robot_status_poll_time
-        )
-        return time_since_last_robot_status_poll > self.robot_status_poll_interval
-
     def run(self) -> None:
         if self.signal_exit.is_set():
             return
 
-        thread_check_interval = settings.THREAD_CHECK_INTERVAL
+        while not self.signal_exit.wait(0):
 
-        while not self.signal_exit.wait(thread_check_interval):
-
-            if not self._is_ready_to_poll_for_status():
-                continue
+            time.sleep(settings.ROBOT_API_STATUS_POLL_INTERVAL)
 
             try:
                 self.last_robot_status_poll_time = time.time()

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -7,7 +7,6 @@ from pytest_mock import MockerFixture
 from isar.config.settings import settings
 from isar.eventhandlers.eventhandler import EventHandlerMapping, State
 from isar.modules import ApplicationContainer
-from isar.robot.robot_status import RobotStatusThread
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
 from isar.state_machine.state_machine import StateMachine
 from isar.state_machine.states.await_next_mission import AwaitNextMission
@@ -41,10 +40,9 @@ def test_state_machine_with_successful_mission_stop(
         StubRobot, "mission_status", return_value=MissionStatus.InProgress
     )
 
-    mocker.patch.object(
-        RobotStatusThread, "_is_ready_to_poll_for_status", return_value=True
-    )
-
+    mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
+    mocker.patch.object(settings, "ROBOT_API_STATUS_POLL_INTERVAL", 0.01)
+    mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 15)
 
     mission: Mission = Mission(

--- a/tests/isar/state_machine/states/test_blocked_protective_stop_state.py
+++ b/tests/isar/state_machine/states/test_blocked_protective_stop_state.py
@@ -3,7 +3,7 @@ from collections import deque
 
 from pytest_mock import MockerFixture
 
-from isar.robot.robot_status import RobotStatusThread
+from isar.config.settings import settings
 from isar.state_machine.states_enum import States
 from tests.test_mocks.robot_interface import StubRobotBlockedProtectiveStopToHomeTest
 from tests.test_mocks.state_machine_mocks import (
@@ -19,9 +19,8 @@ def test_state_machine_idle_to_blocked_protective_stop_to_idle(
 ) -> None:
     # Robot status check happens every 5 seconds by default, so we mock the behavior
     # to poll for status imediately
-    mocker.patch.object(
-        RobotStatusThread, "_is_ready_to_poll_for_status", return_value=True
-    )
+    mocker.patch.object(settings, "ROBOT_API_STATUS_POLL_INTERVAL", 0.01)
+    mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
 
     robot_service_thread.robot_service.robot = StubRobotBlockedProtectiveStopToHomeTest(
         robot_service_thread.robot_service.shared_state.state

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -199,6 +199,9 @@ def test_state_machine_with_unsuccessful_mission_stop_with_mission_id(
     state_machine_thread: StateMachineThreadMock,
     robot_service_thread: RobotServiceThreadMock,
 ) -> None:
+    mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
+    mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
+
     mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
 
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()

--- a/tests/isar/state_machine/test_integration_test_for_states.py
+++ b/tests/isar/state_machine/test_integration_test_for_states.py
@@ -9,7 +9,6 @@ from pytest_mock import MockerFixture
 
 from isar.config.settings import settings
 from isar.modules import ApplicationContainer
-from isar.robot.robot_status import RobotStatusThread
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
 from isar.state_machine.states_enum import States
 from isar.storage.storage_interface import StorageInterface
@@ -123,9 +122,7 @@ def test_state_machine_with_successful_collection(
         0
     ]
 
-    mocker.patch.object(
-        RobotStatusThread, "_is_ready_to_poll_for_status", return_value=True
-    )
+    mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
 
     mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
@@ -169,10 +166,9 @@ def test_state_machine_with_unsuccessful_collection(
 
     mocker.patch.object(StubRobot, "get_inspection", return_value=None)
 
-    mocker.patch.object(
-        RobotStatusThread, "_is_ready_to_poll_for_status", return_value=True
-    )
-
+    mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
+    mocker.patch.object(settings, "ROBOT_API_STATUS_POLL_INTERVAL", 0.01)
+    mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
     state_machine_thread.start()
     robot_service_thread.start()
@@ -240,6 +236,8 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
     robot_service_thread: RobotServiceThreadMock,
     mocker: MockerFixture,
 ) -> None:
+    mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
+    mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
 
     robot_service_thread.robot_service.robot = StubRobotInitiateMissionRaisesException()


### PR DESCRIPTION
Use thread.sleep instead of constantly checking a variable, which makes the threads more consistent.

Increase time between info publishers to avoid unnecessary load on listeners. It is not an issue if it takes slightly longer to be notified of new robots.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test (tests have been updated)
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.