### PR TITLE
Replace fixed test sleeps with condition polling

### DIFF
--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -1,4 +1,3 @@
-import time
 from collections import deque
 from typing import cast
 
@@ -26,6 +25,7 @@ from tests.test_mocks.state_machine_mocks import (
     UploaderThreadMock,
 )
 from tests.test_mocks.task import StubTask
+from tests.wait import wait_until
 
 
 def test_state_machine_with_successful_mission_stop(
@@ -54,13 +54,16 @@ def test_state_machine_with_successful_mission_stop(
     state_machine_thread.start()
     robot_service_thread.start()
     uploader_thread.start()
-    time.sleep(1)
+    wait_until(
+        lambda: States.Home in state_machine_thread.state_machine.transitions_list
+    )
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(0.5)
+    wait_until(
+        lambda: state_machine_thread.state_machine.current_state.name == States.Monitor
+    )
     scheduling_utilities.stop_mission(mission_id=mission.id)
-    time.sleep(3)  # Allow enough time to stop the mission
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.Home,
@@ -68,6 +71,10 @@ def test_state_machine_with_successful_mission_stop(
             States.Stopping,
             States.AwaitNextMission,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
     )
 
 

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -1,4 +1,3 @@
-import time
 from collections import deque
 from http import HTTPStatus
 from typing import cast
@@ -38,6 +37,7 @@ from tests.test_mocks.state_machine_mocks import (
     StateMachineThreadMock,
 )
 from tests.test_mocks.task import StubTask
+from tests.wait import wait_until
 
 
 def _mock_robot_exception_with_message() -> RobotException:
@@ -171,13 +171,17 @@ def test_state_machine_with_unsuccessful_mission_stop(
 
     state_machine_thread.start()
     robot_service_thread.start()
-    time.sleep(1)
+    wait_until(
+        lambda: States.UnknownStatus
+        in state_machine_thread.state_machine.transitions_list
+    )
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(0.5)
+    wait_until(
+        lambda: state_machine_thread.state_machine.current_state.name == States.Monitor
+    )
     scheduling_utilities.stop_mission()
-    time.sleep(2)
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.AwaitNextMission,
@@ -185,6 +189,10 @@ def test_state_machine_with_unsuccessful_mission_stop(
             States.Stopping,
             States.Monitor,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
     )
 
 
@@ -213,7 +221,9 @@ def test_state_machine_with_unsuccessful_mission_stop_with_mission_id(
     robot_service_thread.start()
 
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(1)
+    wait_until(
+        lambda: state_machine_thread.state_machine.current_state.name == States.Monitor
+    )
     with pytest.raises(HTTPException) as exception_details:
         scheduling_utilities.stop_mission(str(uuid4()))
 
@@ -246,15 +256,17 @@ def test_robot_mission_status_exception_handling(
 
     scheduling_utilities.start_mission(mission=mission)
 
-    time.sleep(1)
-
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.AwaitNextMission,
             States.Monitor,
             States.AwaitNextMission,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
     )
 
 

--- a/tests/isar/state_machine/test_integration_test_for_states.py
+++ b/tests/isar/state_machine/test_integration_test_for_states.py
@@ -25,6 +25,7 @@ from tests.test_mocks.state_machine_mocks import (
     UploaderThreadMock,
 )
 from tests.test_mocks.task import StubTask
+from tests.wait import wait_until
 
 
 def test_state_machine_transitions_when_running_full_mission(
@@ -38,7 +39,11 @@ def test_state_machine_transitions_when_running_full_mission(
 
     state_machine_thread.start()
     robot_service_thread.start()
-    time.sleep(1)
+    wait_until(
+        lambda: States.UnknownStatus
+        in state_machine_thread.state_machine.transitions_list
+        and robot_service_thread.robot_service.status_thread is not None
+    )
     # Setting the poll interval to a lower value to ensure that the robot status is
     # updated during the mission. This value needs to be set after the robot service
     # thread has been started.
@@ -55,9 +60,8 @@ def test_state_machine_transitions_when_running_full_mission(
 
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(3)  # Allow enough time to run mission and return home
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.AwaitNextMission,
@@ -66,6 +70,10 @@ def test_state_machine_transitions_when_running_full_mission(
             States.ReturningHome,
             States.Home,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
     )
 
 
@@ -88,12 +96,14 @@ def test_state_machine_failed_dependency(
 
     state_machine_thread.start()
     robot_service_thread.start()
-    time.sleep(1)
+    wait_until(
+        lambda: States.UnknownStatus
+        in state_machine_thread.state_machine.transitions_list
+    )
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(5)  # Allow the state machine to transition through the mission
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.AwaitNextMission,
@@ -106,6 +116,11 @@ def test_state_machine_failed_dependency(
             States.ReturningHome,
             States.InterventionNeeded,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions,
+        timeout=10.0,
     )
 
 
@@ -135,13 +150,13 @@ def test_state_machine_with_successful_collection(
     uploader_thread.start()
 
     robot_service_thread.start()
-    time.sleep(1)
+    wait_until(
+        lambda: States.UnknownStatus
+        in state_machine_thread.state_machine.transitions_list
+    )
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(3)  # Allow enough time to run mission and return home
 
-    expected_stored_items = 1
-    assert len(storage_mock.stored_inspections) == expected_stored_items  # type: ignore
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.Home,
@@ -150,6 +165,11 @@ def test_state_machine_with_successful_collection(
             States.ReturningHome,
             States.Home,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
+        and len(storage_mock.stored_inspections) == 1  # type: ignore
     )
 
 
@@ -175,16 +195,14 @@ def test_state_machine_with_unsuccessful_collection(
     state_machine_thread.start()
     robot_service_thread.start()
     uploader_thread.start()
-    time.sleep(1)
+    wait_until(
+        lambda: States.Home in state_machine_thread.state_machine.transitions_list
+    )
     mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(3)  # Allow enough time to run mission and return home
 
-    expected_stored_items = 0
-    assert len(storage_mock.stored_inspections) == expected_stored_items  # type: ignore
-
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.Home,
@@ -194,6 +212,15 @@ def test_state_machine_with_unsuccessful_collection(
             States.Home,
         ]
     )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
+    )
+    # Mission completion is observable, but confirming no delayed upload requires
+    # a bounded quiet window.
+    time.sleep(0.1)
+    expected_stored_items = 0
+    assert len(storage_mock.stored_inspections) == expected_stored_items  # type: ignore
 
 
 def test_state_machine_with_mission_start_during_return_home_without_queueing_stop_response(
@@ -213,12 +240,17 @@ def test_state_machine_with_mission_start_during_return_home_without_queueing_st
 
     state_machine_thread.start()
     robot_service_thread.start()
-    time.sleep(1)
+    wait_until(
+        lambda: States.UnknownStatus
+        in state_machine_thread.state_machine.transitions_list
+    )
     scheduling_utilities.return_home()
-    time.sleep(1)
+    wait_until(
+        lambda: state_machine_thread.state_machine.current_state.name
+        == States.ReturningHome
+    )
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(1)
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.Home,
@@ -226,6 +258,10 @@ def test_state_machine_with_mission_start_during_return_home_without_queueing_st
             States.StoppingReturnHome,
             States.Monitor,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
     )
     assert (
         not state_machine_thread.state_machine.events.api_requests.start_mission.request.has_event()
@@ -252,12 +288,14 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
     robot_service_thread.start()
 
     # TODO: check mqtt
-    time.sleep(1)
+    wait_until(
+        lambda: States.UnknownStatus
+        in state_machine_thread.state_machine.transitions_list
+    )
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
-    time.sleep(3)  # Allow the state machine to transition through the mission
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.AwaitNextMission,
@@ -270,6 +308,11 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
             States.ReturningHome,
             States.InterventionNeeded,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions,
+        timeout=10.0,
     )
 
 
@@ -286,12 +329,15 @@ def test_state_machine_battery_too_low_to_start_mission(
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
     mocker.patch.object(StubRobot, "get_battery_level", return_value=10.0)
     robot_service_thread.start()
-    time.sleep(1)
 
-    assert state_machine_thread.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.UnknownStatus,
             States.Home,
             States.Recharging,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread.state_machine.transitions_list
+        == expected_transitions
     )

--- a/tests/isar/storage/test_uploader.py
+++ b/tests/isar/storage/test_uploader.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Callable, Tuple
+from typing import Tuple
 from uuid import uuid4
 
 from alitra import Frame, Orientation, Pose, Position
@@ -14,19 +14,9 @@ from tests.test_mocks.blob_storage import StorageEmptyBlobPathsFake, StorageFake
 from tests.test_mocks.inspection import stub_image_metadata
 from tests.test_mocks.mqtt_client import MqttPublisherFake
 from tests.test_mocks.state_machine_mocks import UploaderThreadMock
+from tests.wait import wait_until
 
 MISSION_ID = "some-mission-id"
-
-
-def _wait_until(
-    predicate: Callable[[], bool], timeout: float = 5.0, interval: float = 0.01
-) -> None:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if predicate():
-            return
-        time.sleep(interval)
-    raise AssertionError(f"Timed out after {timeout}s waiting for predicate")
 
 
 def test_should_upload_from_queue(
@@ -66,7 +56,7 @@ def test_should_upload_from_queue(
     storage_handler: StorageFake = uploader.storage_handlers[0]  # type: ignore
 
     uploader.upload_queue.put(message)
-    _wait_until(lambda: inspection in storage_handler.stored_inspections)
+    wait_until(lambda: inspection in storage_handler.stored_inspections)
 
 
 def test_should_retry_failed_upload_from_queue(
@@ -97,7 +87,7 @@ def test_should_retry_failed_upload_from_queue(
     storage_handler.will_fail = False
 
     # Retry succeeds once exponential backoff elapses
-    _wait_until(lambda: storage_handler.blob_exists(inspection), timeout=5.0)
+    wait_until(lambda: storage_handler.blob_exists(inspection), timeout=5.0)
 
 
 def test_should_not_publish_when_blob_paths_are_empty(
@@ -123,7 +113,7 @@ def test_should_not_publish_when_blob_paths_are_empty(
         mission,
     )
     uploader.upload_queue.put(message)
-    _wait_until(lambda: inspection in storage_handler.stored)
+    wait_until(lambda: inspection in storage_handler.stored)
 
     # Brief quiet period to confirm no MQTT publish follows the store
     time.sleep(0.1)
@@ -155,7 +145,7 @@ def test_publishes_required_analysis_when_present(
     mqtt_fake = _put_inspection_with_analysis_types(
         container, ["anonymize", "thermal-reading"]
     )
-    _wait_until(lambda: mqtt_fake.count() == 1)
+    wait_until(lambda: mqtt_fake.count() == 1)
 
     payload = json.loads(mqtt_fake.last()["payload"])
     assert payload["required_analysis"] == ["anonymize", "thermal-reading"]
@@ -166,7 +156,7 @@ def test_publishes_null_required_analysis_when_absent(
 ) -> None:
     uploader_thread.start()
     mqtt_fake = _put_inspection_with_analysis_types(container, None)
-    _wait_until(lambda: mqtt_fake.count() == 1)
+    wait_until(lambda: mqtt_fake.count() == 1)
 
     payload = json.loads(mqtt_fake.last()["payload"])
     assert payload["required_analysis"] is None

--- a/tests/test_persistent_memory.py
+++ b/tests/test_persistent_memory.py
@@ -1,4 +1,3 @@
-import time
 from collections import deque
 from http import HTTPStatus
 
@@ -27,6 +26,7 @@ from tests.test_mocks.state_machine_mocks import (
     RobotServiceThreadMock,
     StateMachineThreadMock,
 )
+from tests.wait import wait_until
 
 
 def test_persistent_storage_schema() -> None:
@@ -79,20 +79,18 @@ def test_lockdown_mode(
     )
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
-
-    t_start = time.time()
-    while (
-        state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
-        != RobotStatus.Home
-    ):
-        if time.time() - t_start > 10:
-            raise Exception("Robot did not come Home within expected time")
-        time.sleep(0.5)
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
+        == RobotStatus.Home,
+        timeout=10.0,
+    )
 
     response = client.post(url="/schedule/release-maintenance-mode")
     assert response.status_code == HTTPStatus.OK
-    time.sleep(1)  # Give time to write to database
-    assert state_machine_thread_with_db.state_machine.current_state.name == States.Home
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.current_state.name
+        == States.Home
+    )
 
     mocker.patch.object(
         StubRobot, "mission_status", return_value=MissionStatus.InProgress
@@ -117,7 +115,11 @@ def test_lockdown_mode(
         StubRobot, "mission_status", return_value=MissionStatus.Successful
     )
 
-    time.sleep(3)
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.current_state.name
+        == States.Lockdown,
+        timeout=10.0,
+    )
 
     response = client.post(
         url="/schedule/start-mission",
@@ -129,9 +131,7 @@ def test_lockdown_mode(
     )
     assert response.status_code == HTTPStatus.CONFLICT
 
-    time.sleep(10)  # Give the state machine enough time to stop the mission
-
-    assert state_machine_thread_with_db.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.Maintenance,
             States.UnknownStatus,
@@ -141,6 +141,11 @@ def test_lockdown_mode(
             States.GoingToLockdown,
             States.Lockdown,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.transitions_list
+        == expected_transitions,
+        timeout=10.0,
     )
 
     robot_startup_mode = read_or_create_persistent_mode()
@@ -175,19 +180,18 @@ def test_maintenance_mode(
     assert response.status_code == HTTPStatus.CONFLICT
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
-    t_start = time.time()
-    while (
-        state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
-        != RobotStatus.Home
-    ):
-        if time.time() - t_start > 10:
-            raise Exception("Robot did not come Home within expected time")
-        time.sleep(0.5)
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
+        == RobotStatus.Home,
+        timeout=10.0,
+    )
 
     response = client.post(url="/schedule/release-maintenance-mode")
     assert response.status_code == HTTPStatus.OK
-    time.sleep(1)  # Give time to write to database
-    assert state_machine_thread_with_db.state_machine.current_state.name == States.Home
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.current_state.name
+        == States.Home
+    )
 
     mocker.patch.object(
         StubRobot, "mission_status", return_value=MissionStatus.InProgress
@@ -218,9 +222,7 @@ def test_maintenance_mode(
     )
     assert response.status_code == HTTPStatus.CONFLICT
 
-    time.sleep(5)  # Give the state machine enough time to stop the mission
-
-    assert state_machine_thread_with_db.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.Maintenance,
             States.UnknownStatus,
@@ -229,6 +231,11 @@ def test_maintenance_mode(
             States.StoppingDueToMaintenance,
             States.Maintenance,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.transitions_list
+        == expected_transitions,
+        timeout=10.0,
     )
 
 
@@ -248,28 +255,26 @@ def test_release_maintenance_mode(
     )
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
-    t_start = time.time()
-    while (
-        state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
-        != RobotStatus.Home
-    ):
-        if time.time() - t_start > 10:
-            raise Exception("Robot did not come Home within expected time")
-        time.sleep(0.5)
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
+        == RobotStatus.Home,
+        timeout=10.0,
+    )
 
     response = client.post(url="/schedule/release-maintenance-mode")
     assert response.status_code == HTTPStatus.OK
-    time.sleep(1)  # Give time to write to database
-    assert state_machine_thread_with_db.state_machine.current_state.name == States.Home
+    wait_until(
+        lambda: read_persistent_robot_state(settings.ISAR_ID) == RobotStartupMode.Normal
+    )
 
-    robotStartUpMode = read_persistent_robot_state(settings.ISAR_ID)
-
-    assert robotStartUpMode == RobotStartupMode.Normal
-
-    assert state_machine_thread_with_db.state_machine.transitions_list == deque(
+    expected_transitions = deque(
         [
             States.Maintenance,
             States.UnknownStatus,
             States.Home,
         ]
+    )
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.transitions_list
+        == expected_transitions
     )

--- a/tests/wait.py
+++ b/tests/wait.py
@@ -1,0 +1,15 @@
+import time
+from collections.abc import Callable
+
+
+def wait_until(
+    predicate: Callable[[], bool],
+    timeout: float = 5.0,
+    interval: float = 0.01,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(f"Timed out after {timeout}s waiting for predicate")


### PR DESCRIPTION
## Summary

Closes #1134.

- promote the uploader's polling helper to `tests.wait.wait_until`
- replace fixed startup and completion sleeps with observable state-machine, persistence, upload, and transition predicates
- retain short sleeps only for assertions that intentionally verify no delayed event occurs during a bounded quiet window

This keeps the change entirely in the test suite and lets each assertion proceed as soon as its condition is true instead of waiting a guessed duration.

## Verification

- Focused affected suite: 25 passed
- Timing-sensitive repeat: 7 passed
- Persistent-memory tests: all passed; one initial MySQL testcontainers startup timed out before the test body, then passed on isolated retry
- Persisted-mode release repeat: 1 passed
- `ruff check` on all changed files
- `black --check` on all changed files
- `isort --check-only` on all changed files
- `git diff --check`

`uv.lock` remains unchanged.
