### PR TITLE
Simplify inspection ID and mission models in general

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ Here is an example body:
             'zoom': None
          }
       ],
-      'name': 'Example name',
-      'start_pose': None
+      'name': 'Example name'
    }
 }
 

--- a/src/isar/apis/models/models.py
+++ b/src/isar/apis/models/models.py
@@ -9,7 +9,6 @@ from robot_interface.models.mission.task import TaskTypes
 class TaskResponse(BaseModel):
     id: str
     tag_id: str | None = None
-    inspection_id: str | None = None
     type: TaskTypes
 
 

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -71,7 +71,6 @@ class StartMissionDefinition(BaseModel):
     id: str | None = None
     tasks: List[StartMissionTaskDefinition]
     name: str | None = None
-    start_pose: InputPose | None = None
 
 
 class StopMissionDefinition(BaseModel):
@@ -100,17 +99,12 @@ def to_isar_mission(
         else _build_mission_name()
     )
 
-    start_pose = None
-    if start_mission_definition.start_pose:
-        start_pose = start_mission_definition.start_pose.to_alitra_pose()
-
     id = start_mission_definition.id if start_mission_definition.id else str(uuid4())
 
     return Mission(
         id=id,
         tasks=isar_tasks,
         name=isar_mission_name,
-        start_pose=start_pose,
     )
 
 

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -59,7 +59,7 @@ class StartMissionInspectionDefinition(BaseModel):
 
 
 class StartMissionTaskDefinition(BaseModel):
-    id: str | None = None
+    id: str = Field()
     type: TaskType = Field(default=TaskType.Inspection)
     pose: InputPose
     inspection: StartMissionInspectionDefinition | None = None
@@ -170,7 +170,7 @@ def to_inspection_task(task_definition: StartMissionTaskDefinition) -> TASKS:
         )
 
     kwargs: dict = {
-        "id": task_definition.id if task_definition.id else str(uuid4()),
+        "id": task_definition.id,
         "robot_pose": task_definition.pose.to_alitra_pose(),
         "tag_id": task_definition.tag,
         "inspection_description": inspection_definition.inspection_description,

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -13,7 +13,6 @@ from robot_interface.models.mission.task import (
     AcousticDetectionType,
     InspectionTask,
     RecordAudio,
-    ReturnToHome,
     Roi,
     TakeAcousticMeasurement,
     TakeCO2Measurement,
@@ -35,11 +34,6 @@ class InspectionTypes(str, Enum):
     acoustic_measurement = "AcousticMeasurement"
 
 
-class TaskType(str, Enum):
-    Inspection = "inspection"
-    ReturnToHome = "return_to_home"
-
-
 class AcousticInspectionParameters(BaseModel):
     frequency_from: float
     frequency_to: float
@@ -59,7 +53,6 @@ class StartMissionInspectionDefinition(BaseModel):
 
 class StartMissionTaskDefinition(BaseModel):
     id: str = Field()
-    type: TaskType = Field(default=TaskType.Inspection)
     pose: InputPose
     inspection: StartMissionInspectionDefinition | None = None
     tag: str | None = None
@@ -86,7 +79,7 @@ def to_isar_mission(
     isar_tasks: List[TASKS] = []
 
     for task_definition in start_mission_definition.tasks:
-        task: TASKS = to_isar_task(task_definition)
+        task: TASKS = to_inspection_task(task_definition)
         isar_tasks.append(task)
 
     if not isar_tasks:
@@ -103,17 +96,6 @@ def to_isar_mission(
         tasks=isar_tasks,
         name=isar_mission_name,
     )
-
-
-def to_isar_task(task_definition: StartMissionTaskDefinition) -> TASKS:
-    if task_definition.type == TaskType.Inspection:
-        return to_inspection_task(task_definition)
-    elif task_definition.type == TaskType.ReturnToHome:
-        return ReturnToHome()
-    else:
-        raise MissionFormatError(
-            f"Failed to create task: '{task_definition.type}' is not a valid"
-        )
 
 
 @dataclass(frozen=True)

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -2,7 +2,6 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Type
-from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
@@ -68,7 +67,7 @@ class StartMissionTaskDefinition(BaseModel):
 
 
 class StartMissionDefinition(BaseModel):
-    id: str | None = None
+    id: str = Field()
     tasks: List[StartMissionTaskDefinition]
     name: str | None = None
 
@@ -99,10 +98,8 @@ def to_isar_mission(
         else _build_mission_name()
     )
 
-    id = start_mission_definition.id if start_mission_definition.id else str(uuid4())
-
     return Mission(
-        id=id,
+        id=start_mission_definition.id,
         tasks=isar_tasks,
         name=isar_mission_name,
     )

--- a/src/isar/apis/schedule/scheduling_controller.py
+++ b/src/isar/apis/schedule/scheduling_controller.py
@@ -19,7 +19,7 @@ from isar.config.settings import robot_settings
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
 from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
-from robot_interface.models.mission.task import TASKS, InspectionTask
+from robot_interface.models.mission.task import TASKS
 
 tracer = trace.get_tracer(__name__)
 
@@ -261,11 +261,4 @@ class SchedulingController:
         )
 
     def _task_api_response(self, task: TASKS) -> TaskResponse:
-        if isinstance(task, InspectionTask):
-            inspection_id = task.inspection_id
-        else:
-            inspection_id = None
-
-        return TaskResponse(
-            id=task.id, tag_id=task.tag_id, inspection_id=inspection_id, type=task.type
-        )
+        return TaskResponse(id=task.id, tag_id=task.tag_id, type=task.type)

--- a/src/isar/robot/robot_inspection_service.py
+++ b/src/isar/robot/robot_inspection_service.py
@@ -27,9 +27,9 @@ def robot_upload_inspection(
 ) -> None:
     try:
         inspection: Inspection = robot.get_inspection(task=task)
-        if task.inspection_id != inspection.id:
+        if task.id != inspection.id:
             logger.warning(
-                f"The inspection_id of task ({task.inspection_id}) "
+                f"The id of task ({task.id}) "
                 f"and result ({inspection.id}) is not matching. "
                 f"This may lead to confusions when accessing the inspection later"
             )

--- a/src/isar/robot/robot_service.py
+++ b/src/isar/robot/robot_service.py
@@ -107,7 +107,6 @@ class RobotService:
                         id=aborted_mission.id,
                         name=aborted_mission.name,
                         tasks=unfinished_tasks,
-                        start_pose=aborted_mission.start_pose,
                     )
                     self.robot_service_events.mission_successfully_stopped.trigger_event(
                         continued_mission

--- a/src/robot_interface/models/mission/mission.py
+++ b/src/robot_interface/models/mission/mission.py
@@ -9,7 +9,7 @@ from robot_interface.models.mission.task import TASKS, ReturnToHome, TaskTypes
 
 
 class Mission(BaseModel):
-    id: str = Field(default_factory=lambda: str(uuid4()), frozen=True)
+    id: str = Field(frozen=True)
     tasks: List[TASKS] = Field(default_factory=list, frozen=True)
     name: str = Field(frozen=True)
     status: MissionStatus = MissionStatus.NotStarted
@@ -37,5 +37,6 @@ class Mission(BaseModel):
 
 
 class ReturnHomeMission(Mission):
+    id: str = str(uuid4())
     tasks: List[TASKS] = Field(default_factory=lambda: [ReturnToHome()])
     name: str = "Return Home"

--- a/src/robot_interface/models/mission/mission.py
+++ b/src/robot_interface/models/mission/mission.py
@@ -1,7 +1,6 @@
 from typing import List
 from uuid import uuid4
 
-from alitra import Pose
 from pydantic import BaseModel, Field
 
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
@@ -13,7 +12,6 @@ class Mission(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()), frozen=True)
     tasks: List[TASKS] = Field(default_factory=list, frozen=True)
     name: str = Field(frozen=True)
-    start_pose: Pose | None = Field(default=None, frozen=True)
     status: MissionStatus = MissionStatus.NotStarted
     error_message: ErrorMessage | None = Field(default=None)
 

--- a/src/robot_interface/models/mission/task.py
+++ b/src/robot_interface/models/mission/task.py
@@ -65,7 +65,6 @@ class InspectionTask(Task):
     Base class for all inspection tasks which produce results to be uploaded.
     """
 
-    inspection_id: str = Field(default_factory=lambda: str(uuid4()), frozen=True)
     robot_pose: Pose = Field()
     inspection_description: str | None = Field(default=None)
     zoom: ZoomDescription | None = Field(default=None)

--- a/src/robot_interface/models/mission/task.py
+++ b/src/robot_interface/models/mission/task.py
@@ -57,7 +57,7 @@ class Task(BaseModel):
     status: TaskStatus = Field(default=TaskStatus.NotStarted)
     error_message: ErrorMessage | None = Field(default=None)
     tag_id: str | None = Field(default=None)
-    id: str = Field(default_factory=lambda: str(uuid4()), frozen=True)
+    id: str = Field(frozen=True)
 
 
 class InspectionTask(Task):
@@ -80,6 +80,7 @@ class ReturnToHome(Task):
     Task which cases the robot to return home
     """
 
+    id: str = str(uuid4())
     type: Literal[TaskTypes.ReturnToHome] = TaskTypes.ReturnToHome
 
 

--- a/tests/isar/apis/models/test_start_mission_definition.py
+++ b/tests/isar/apis/models/test_start_mission_definition.py
@@ -34,6 +34,7 @@ def test_to_isar_mission() -> None:
         orientation=InputOrientation(x=1, y=1, z=1, w=1),
     )
     task_definition = StartMissionTaskDefinition(
+        id="test-id",
         type=TaskType.Inspection,
         pose=task_pose,
         inspection=inspection_definition,
@@ -54,7 +55,7 @@ def test_to_isar_mission() -> None:
     assert isinstance(first_task, TakeImage)
 
     assert first_task.target == Position(x=1, y=1, z=1, frame=Frame(name="robot"))
-    assert len(first_task.inspection_id) > 1
+    assert len(first_task.id) > 1
     assert first_task.robot_pose == Pose(
         position=Position(x=1, y=1, z=1, frame=Frame(name="robot")),
         orientation=Orientation(x=1, y=1, z=1, w=1, frame=Frame(name="robot")),
@@ -93,6 +94,7 @@ def _build_mission_with_inspection_payload(inspection_payload: dict) -> Mission:
         "name": "mission",
         "tasks": [
             {
+                "id": "dummy_id",
                 "type": "inspection",
                 "pose": {
                     "position": {"x": 0, "y": 0, "z": 0},

--- a/tests/isar/apis/models/test_start_mission_definition.py
+++ b/tests/isar/apis/models/test_start_mission_definition.py
@@ -40,7 +40,7 @@ def test_to_isar_mission() -> None:
         inspection=inspection_definition,
     )
     mission_definition = StartMissionDefinition(
-        tasks=[task_definition], name=DUMMY_MISSION_NAME
+        tasks=[task_definition], name=DUMMY_MISSION_NAME, id="test-id2"
     )
 
     isar_mission: Mission = to_isar_mission(mission_definition)
@@ -91,6 +91,7 @@ def test_mission_definition_from_json_to_isar_mission() -> None:
 
 def _build_mission_with_inspection_payload(inspection_payload: dict) -> Mission:
     payload = {
+        "id": "dummy_mission_id",
         "name": "mission",
         "tasks": [
             {

--- a/tests/isar/apis/models/test_start_mission_definition.py
+++ b/tests/isar/apis/models/test_start_mission_definition.py
@@ -10,7 +10,6 @@ from isar.apis.models.start_mission_definition import (
     StartMissionDefinition,
     StartMissionInspectionDefinition,
     StartMissionTaskDefinition,
-    TaskType,
     to_isar_mission,
 )
 from robot_interface.models.mission.mission import Mission
@@ -35,7 +34,6 @@ def test_to_isar_mission() -> None:
     )
     task_definition = StartMissionTaskDefinition(
         id="test-id",
-        type=TaskType.Inspection,
         pose=task_pose,
         inspection=inspection_definition,
     )

--- a/tests/isar/services/robot/test_robot_service.py
+++ b/tests/isar/services/robot/test_robot_service.py
@@ -19,8 +19,10 @@ def test_mission_fails_to_schedule(
 ) -> None:
     r_service = mocked_robot_service
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1])
 
     mocker.patch(
         "isar.robot.robot_service.robot_start_mission",
@@ -43,8 +45,10 @@ def test_mission_succeeds_to_schedule(
 ) -> None:
     r_service = mocked_robot_service
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1])
 
     mocker.patch("isar.robot.robot_service.robot_start_mission", return_value=None)
 
@@ -84,11 +88,12 @@ def test_successful_stop_with_remaining_tasks(
     mocker.patch("isar.robot.robot_service.robot_stop_mission", return_value=None)
 
     task_1: Task = TakeImage(
+        id="id",
         target=stub_pose().position,
         robot_pose=stub_pose(),
         status=TaskStatus.Cancelled,
     )
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1])
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1])
 
     mocker.patch(
         "isar.robot.robot_service.robot_monitor_mission",
@@ -118,11 +123,12 @@ def test_successful_stop_with_no_remaining_tasks(
     mocker.patch("isar.robot.robot_service.robot_stop_mission", return_value=None)
 
     task_1: Task = TakeImage(
+        id="id",
         target=stub_pose().position,
         robot_pose=stub_pose(),
         status=TaskStatus.Successful,
     )
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1])
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1])
 
     mocker.patch(
         "isar.robot.robot_service.robot_monitor_mission",
@@ -164,8 +170,10 @@ def test_monitor_mission_reports_nothing_after_mission_stopped(
 ) -> None:
     r_service = mocked_robot_service
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1])
 
     mocker.patch(
         "isar.robot.robot_service.robot_monitor_mission",
@@ -183,8 +191,10 @@ def test_monitor_mission_reports_mission_failed(
 ) -> None:
     r_service = mocked_robot_service
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1])
 
     mocker.patch(
         "isar.robot.robot_service.robot_monitor_mission",
@@ -206,8 +216,10 @@ def test_monitor_mission_reports_mission_success(
 ) -> None:
     r_service = mocked_robot_service
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1])
 
     mocker.patch(
         "isar.robot.robot_service.robot_monitor_mission",
@@ -302,8 +314,10 @@ def test_start_mission_reports_robot_already_home(
 
     r_service.robot.initiate_mission = mock_initiate_mission  # type: ignore
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy mission", tasks=[task_1])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy mission", tasks=[task_1])
     success = r_service._start_mission_handler(mission)
 
     assert not success

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -46,7 +46,9 @@ def test_state_machine_with_successful_mission_stop(
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 15)
 
     mission: Mission = Mission(
-        name="Dummy misson", tasks=[StubTask.take_image() for _ in range(0, 20)]
+        id="id",
+        name="Dummy misson",
+        tasks=[StubTask.take_image() for _ in range(0, 20)],
     )
 
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()

--- a/tests/isar/state_machine/states/test_going_to_recharging_state.py
+++ b/tests/isar/state_machine/states/test_going_to_recharging_state.py
@@ -41,7 +41,7 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
 
     assert event_handler is not None
 
-    transition = event_handler.handler(AbortedMission(name="test"))
+    transition = event_handler.handler(AbortedMission(id="id", name="test"))
 
     assert sync_state_machine.events.mqtt_queue.empty()
 

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -159,7 +159,9 @@ def test_state_machine_with_unsuccessful_mission_stop(
     robot_service_thread: RobotServiceThreadMock,
 ) -> None:
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
 
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     mocker.patch.object(
@@ -205,7 +207,9 @@ def test_state_machine_with_unsuccessful_mission_stop_with_mission_id(
     mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
 
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
 
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     mocker.patch.object(
@@ -241,9 +245,9 @@ def test_robot_mission_status_exception_handling(
     container: ApplicationContainer,
     state_machine_thread: StateMachineThreadMock,
     robot_service_thread: RobotServiceThreadMock,
-    mocker: MockerFixture,
 ) -> None:
     mission = Mission(
+        id="id",
         name="Dummy mission",
         tasks=[StubTask.take_image()],
     )

--- a/tests/isar/state_machine/states/test_return_home_paused_state.py
+++ b/tests/isar/state_machine/states/test_return_home_paused_state.py
@@ -61,7 +61,7 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
 
     assert event_handler is not None
 
-    example_mission: Mission = Mission(name="Dummy misson", tasks=[])
+    example_mission: Mission = Mission(id="id", name="Dummy misson", tasks=[])
 
     transition = event_handler.handler(example_mission)
 

--- a/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
@@ -15,7 +15,9 @@ from tests.test_mocks.task import StubTask
 def test_transition_to_stopping_paused_return_home_replies_to_API(
     sync_state_machine: StateMachine,
 ) -> None:
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     sync_state_machine.current_state = ReturnHomePaused(sync_state_machine.events)
     return_home_paused_state: State = cast(State, sync_state_machine.current_state)
     event_handler: EventHandlerMapping | None = (
@@ -34,7 +36,9 @@ def test_transition_to_stopping_paused_return_home_replies_to_API(
 def test_stopping_paused_return_home_mission_fails(
     sync_state_machine: StateMachine,
 ) -> None:
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     sync_state_machine.current_state = StoppingPausedReturnHome(
         sync_state_machine.events, mission
     )
@@ -58,7 +62,9 @@ def test_stopping_paused_return_home_mission_fails(
 def test_stopping_paused_return_home_mission_succeeds(
     sync_state_machine: StateMachine,
 ) -> None:
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     sync_state_machine.current_state = StoppingPausedReturnHome(
         sync_state_machine.events, mission
     )

--- a/tests/isar/state_machine/states/test_stopping_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_return_home_state.py
@@ -21,7 +21,9 @@ def test_return_home_cancelled_when_new_mission_received(
         returning_home_state.get_event_handler_by_name("start_mission_event")
     )
 
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
 
     assert event_handler is not None
 
@@ -34,7 +36,9 @@ def test_return_home_cancelled_when_new_mission_received(
 def test_transition_to_stopping_return_home_replies_to_API(
     sync_state_machine: StateMachine,
 ) -> None:
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     sync_state_machine.current_state = ReturningHome(sync_state_machine.events)
     returning_home_state: State = cast(State, sync_state_machine.current_state)
     event_handler: EventHandlerMapping | None = (
@@ -53,7 +57,9 @@ def test_transition_to_stopping_return_home_replies_to_API(
 def test_stopping_return_home_mission_fails(
     sync_state_machine: StateMachine,
 ) -> None:
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     sync_state_machine.current_state = StoppingReturnHome(
         sync_state_machine.events, mission
     )
@@ -77,7 +83,9 @@ def test_stopping_return_home_mission_fails(
 def test_stopping_return_home_mission_succeeds(
     sync_state_machine: StateMachine,
 ) -> None:
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     sync_state_machine.current_state = StoppingReturnHome(
         sync_state_machine.events, mission
     )

--- a/tests/isar/state_machine/test_integration_test_for_states.py
+++ b/tests/isar/state_machine/test_integration_test_for_states.py
@@ -54,9 +54,13 @@ def test_state_machine_transitions_when_running_full_mission(
         )
     )
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    task_2: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy mission", tasks=[task_1, task_2])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    task_2: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy mission", tasks=[task_1, task_2])
 
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
@@ -87,9 +91,13 @@ def test_state_machine_failed_dependency(
     mocker.patch.object(settings, "RETURN_HOME_RETRY_LIMIT", 3)
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    task_2: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1, task_2])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    task_2: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1, task_2])
 
     mocker.patch.object(StubRobot, "task_status", return_value=TaskStatus.Failed)
     mocker.patch.object(StubRobot, "mission_status", return_value=MissionStatus.Failed)
@@ -142,7 +150,9 @@ def test_state_machine_with_successful_collection(
     mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
 
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
 
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
@@ -198,7 +208,9 @@ def test_state_machine_with_unsuccessful_collection(
     wait_until(
         lambda: States.Home in state_machine_thread.state_machine.transitions_list
     )
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
 
@@ -230,7 +242,9 @@ def test_state_machine_with_mission_start_during_return_home_without_queueing_st
     robot_service_thread: RobotServiceThreadMock,
 ) -> None:
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
-    mission: Mission = Mission(name="Dummy misson", tasks=[StubTask.take_image()])
+    mission: Mission = Mission(
+        id="id", name="Dummy misson", tasks=[StubTask.take_image()]
+    )
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     mocker.patch.object(
         StubRobot, "mission_status", return_value=MissionStatus.InProgress
@@ -280,9 +294,13 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
 
     robot_service_thread.robot_service.robot = StubRobotInitiateMissionRaisesException()
 
-    task_1: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    task_2: Task = TakeImage(target=stub_pose().position, robot_pose=stub_pose())
-    mission: Mission = Mission(name="Dummy misson", tasks=[task_1, task_2])
+    task_1: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    task_2: Task = TakeImage(
+        id="id", target=stub_pose().position, robot_pose=stub_pose()
+    )
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[task_1, task_2])
 
     state_machine_thread.start()
     robot_service_thread.start()

--- a/tests/isar/storage/test_uploader.py
+++ b/tests/isar/storage/test_uploader.py
@@ -40,7 +40,7 @@ def test_should_upload_from_queue(
         target=pose.position,
         zoom=None,
     )
-    mission: Mission = Mission(name="Dummy misson", tasks=[take_image_task])
+    mission: Mission = Mission(id="id", name="Dummy misson", tasks=[take_image_task])
 
     assert isinstance(mission.tasks[0], TakeImage)
     inspection = InspectionBlob(metadata=stub_image_metadata(), id=mission.tasks[0].id)
@@ -64,7 +64,7 @@ def test_should_retry_failed_upload_from_queue(
 
     INSPECTION_ID = "123-456"
     inspection = InspectionBlob(metadata=stub_image_metadata(), id=INSPECTION_ID)
-    mission: Mission = Mission(name="Dummy Mission")
+    mission: Mission = Mission(id="id", name="Dummy Mission")
 
     message: Tuple[Inspection, Mission] = (
         inspection,
@@ -93,7 +93,7 @@ def test_should_not_publish_when_blob_paths_are_empty(
 ) -> None:
     uploader_thread.start()
 
-    mission: Mission = Mission(name="Dummy mission")
+    mission: Mission = Mission(id="id", name="Dummy mission")
     inspection: Inspection = InspectionBlob(
         metadata=stub_image_metadata(), id="blob-empty"
     )
@@ -125,7 +125,7 @@ def _put_inspection_with_analysis_types(
     inspection = InspectionBlob(
         metadata=stub_image_metadata(analysis_types=analysis_types), id=str(uuid4())
     )
-    mission = Mission(name="m")
+    mission = Mission(id="id", name="m")
 
     uploader: Uploader = container.uploader()
     mqtt_fake = MqttPublisherFake()

--- a/tests/isar/storage/test_uploader.py
+++ b/tests/isar/storage/test_uploader.py
@@ -43,9 +43,7 @@ def test_should_upload_from_queue(
     mission: Mission = Mission(name="Dummy misson", tasks=[take_image_task])
 
     assert isinstance(mission.tasks[0], TakeImage)
-    inspection = InspectionBlob(
-        metadata=stub_image_metadata(), id=mission.tasks[0].inspection_id
-    )
+    inspection = InspectionBlob(metadata=stub_image_metadata(), id=mission.tasks[0].id)
 
     message: Tuple[Inspection, Mission] = (
         inspection,

--- a/tests/isar/storage/test_utilities.py
+++ b/tests/isar/storage/test_utilities.py
@@ -15,7 +15,9 @@ def test_construct_metadata_file_acoustic_includes_result_block() -> None:
     )
 
     raw = construct_metadata_file(
-        inspection=inspection, mission=Mission(name="m", tasks=[]), filename="f"
+        inspection=inspection,
+        mission=Mission(id="id", name="m", tasks=[]),
+        filename="f",
     )
     data = json.loads(raw)
 
@@ -36,7 +38,9 @@ def test_construct_metadata_file_non_acoustic_excludes_acoustic_result() -> None
     inspection = Image(id="image-1", metadata=stub_image_metadata())
 
     raw = construct_metadata_file(
-        inspection=inspection, mission=Mission(name="m", tasks=[]), filename="f"
+        inspection=inspection,
+        mission=Mission(id="id", name="m", tasks=[]),
+        filename="f",
     )
     data = json.loads(raw)
 

--- a/tests/test_mocks/mission_definition.py
+++ b/tests/test_mocks/mission_definition.py
@@ -55,7 +55,7 @@ class DummyMissionDefinition:
     dummy_task_response_take_image = TaskResponse(
         id=dummy_task_take_image.id,
         tag_id=dummy_task_take_image.tag_id,
-        inspection_id=dummy_task_take_image.inspection_id,
+        inspection_id=dummy_task_take_image.id,
         type=dummy_task_take_image.type,
     )
 
@@ -66,6 +66,7 @@ class DummyMissionDefinition:
     dummy_start_mission_definition = StartMissionDefinition(
         tasks=[
             StartMissionTaskDefinition(
+                id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition,
@@ -75,11 +76,13 @@ class DummyMissionDefinition:
     dummy_start_mission_definition_image_and_thermal = StartMissionDefinition(
         tasks=[
             StartMissionTaskDefinition(
+                id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition,
             ),
             StartMissionTaskDefinition(
+                id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition_thermal_image,
@@ -89,16 +92,19 @@ class DummyMissionDefinition:
     dummy_start_mission_definition_task_ids = StartMissionDefinition(
         tasks=[
             StartMissionTaskDefinition(
+                id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition,
             ),
             StartMissionTaskDefinition(
+                id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition,
             ),
             StartMissionTaskDefinition(
+                id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition,

--- a/tests/test_mocks/mission_definition.py
+++ b/tests/test_mocks/mission_definition.py
@@ -64,6 +64,7 @@ class DummyMissionDefinition:
         tasks=[dummy_task_response_take_image],
     )
     dummy_start_mission_definition = StartMissionDefinition(
+        id="test-id",
         tasks=[
             StartMissionTaskDefinition(
                 id="dummy_id",
@@ -71,9 +72,10 @@ class DummyMissionDefinition:
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition,
             ),
-        ]
+        ],
     )
     dummy_start_mission_definition_image_and_thermal = StartMissionDefinition(
+        id="test-id",
         tasks=[
             StartMissionTaskDefinition(
                 id="dummy_id",
@@ -87,9 +89,10 @@ class DummyMissionDefinition:
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition_thermal_image,
             ),
-        ]
+        ],
     )
     dummy_start_mission_definition_task_ids = StartMissionDefinition(
+        id="test-id",
         tasks=[
             StartMissionTaskDefinition(
                 id="dummy_id",
@@ -109,5 +112,5 @@ class DummyMissionDefinition:
                 tag="dummy_tag",
                 inspection=dummy_start_mission_inspection_definition,
             ),
-        ]
+        ],
     )

--- a/tests/test_mocks/robot_interface.py
+++ b/tests/test_mocks/robot_interface.py
@@ -65,7 +65,7 @@ class StubRobot(RobotInterface):
     def get_inspection(self, task: InspectionTask) -> Inspection:
         return Image(
             metadata=stub_image_metadata(),
-            id=task.inspection_id,
+            id=task.id,
             data=b"Some binary image data",
         )
 

--- a/tests/test_mocks/task.py
+++ b/tests/test_mocks/task.py
@@ -13,4 +13,6 @@ class StubTask:
             orientation=Orientation(x=0, y=0, z=0, w=1, frame=Frame("robot")),
             frame=Frame("robot"),
         )
-        return TakeImage(target=target_pose, robot_pose=robot_pose, status=status)
+        return TakeImage(
+            id="dummy-id", target=target_pose, robot_pose=robot_pose, status=status
+        )


### PR DESCRIPTION
Breaking change since previously nullable IDs in API models are becoming required.

Related flotilla PR (second commit): https://github.com/equinor/flotilla/pull/2844

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.