### PR TITLE
Simplify uploader and make tests deterministic

### DIFF
--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -16,8 +16,6 @@ from robot_interface.models.mission.status import RobotStatus
 from robot_interface.models.mission.task import InspectionTask
 from robot_interface.telemetry.mqtt_client import MQTTQueueType
 
-InspectionQueueTuple = tuple[Inspection, Mission]
-
 
 class EmptyMessage:
     def __str__(self) -> str:
@@ -28,8 +26,8 @@ AbortedMission = Mission
 
 
 class Event[T](Queue[T]):
-    def __init__(self, name: str) -> None:
-        super().__init__(maxsize=1)
+    def __init__(self, name: str, maxsize: int = 1) -> None:
+        super().__init__(maxsize=maxsize)
         self.name = name
 
     def trigger_event(self, data: T, timeout: int | None = None) -> None:
@@ -90,8 +88,8 @@ class Events:
         self.state_machine_events: StateMachineEvents = StateMachineEvents()
         self.robot_service_events: RobotServiceEvents = RobotServiceEvents()
 
-        self.upload_queue: Queue[InspectionQueueTuple] = Queue[InspectionQueueTuple](
-            maxsize=10
+        self.upload_event: Event[tuple[Inspection, Mission]] = Event(
+            "uploader", maxsize=10
         )
 
         self.mqtt_queue: Queue[MQTTQueueType] = Queue[MQTTQueueType]()

--- a/src/isar/modules.py
+++ b/src/isar/modules.py
@@ -85,20 +85,16 @@ class ApplicationContainer(containers.DeclarativeContainer):
         mqtt_publisher=mqtt_client,
     )
 
-    # Inspection data service
-    inspection_service = providers.Singleton(
-        RobotInspectionService,
-        events=events,
-        robot=robot_interface,
-        mqtt_publisher=mqtt_client,
-    )
-
     # Uploader
     uploader = providers.Singleton(
         Uploader,
-        events=events,
         storage_handlers=storage_handlers,
         mqtt_publisher=mqtt_client,
+    )
+
+    # Inspection data service
+    inspection_service = providers.Singleton(
+        RobotInspectionService, events=events, robot=robot_interface, uploader=uploader
     )
 
 

--- a/src/isar/robot/robot_inspection_service.py
+++ b/src/isar/robot/robot_inspection_service.py
@@ -1,18 +1,12 @@
 import logging
 from collections.abc import Callable
-from queue import Queue
 from threading import Event as ThreadEvent
 from threading import Thread
 
 from isar.config.settings import settings
-from isar.models.events import (
-    EventConflictError,
-    Events,
-    EventTimeoutError,
-    RobotServiceEvents,
-    StateMachineEvents,
-)
+from isar.models.events import Event, EventConflictError, Events, EventTimeoutError
 from isar.robot.function_thread import FunctionThread
+from isar.storage.uploader import Uploader
 from robot_interface.models.exceptions.robot_exceptions import (
     RobotException,
     RobotRetrieveInspectionException,
@@ -21,18 +15,17 @@ from robot_interface.models.inspection.inspection import Inspection
 from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.task import InspectionTask
 from robot_interface.robot_interface import RobotInterface
-from robot_interface.telemetry.mqtt_client import MqttClientInterface
 
 
-def robot_upload_inspection(
-    robot: RobotInterface,
+def fetch_and_upload_inspection(
+    get_inspection_function: Callable[[InspectionTask], Inspection],
     logger: logging.Logger,
+    upload_function: Callable[[Inspection, Mission], None],
     task: InspectionTask,
     mission: Mission,
-    upload_queue: Queue,
 ) -> None:
     try:
-        inspection: Inspection = robot.get_inspection(task=task)
+        inspection: Inspection = get_inspection_function(task)
         if task.id != inspection.id:
             logger.warning(
                 f"The id of task ({task.id}) "
@@ -45,19 +38,13 @@ def robot_upload_inspection(
         return
 
     if not inspection:
-        logger.warning(
-            f"No inspection result data retrieved for task {str(task.id)[:8]}"
-        )
+        logger.error(f"No inspection result data retrieved for task {str(task.id)[:8]}")
+        return
 
     inspection.metadata.tag_id = task.tag_id
     inspection.metadata.analysis_types = task.analysis_types
 
-    message: tuple[Inspection, Mission] = (
-        inspection,
-        mission,
-    )
-    upload_queue.put(message)
-    logger.info(f"Inspection result: {str(inspection.id)[:8]} queued for upload")
+    upload_function(inspection, mission)
 
 
 class RobotInspectionService:
@@ -65,13 +52,16 @@ class RobotInspectionService:
         self,
         events: Events,
         robot: RobotInterface,
-        mqtt_publisher: MqttClientInterface,
+        uploader: Uploader,
     ) -> None:
         self.logger = logging.getLogger("uploader")
-        self.state_machine_events: StateMachineEvents = events.state_machine_events
-        self.robot_service_events: RobotServiceEvents = events.robot_service_events
-        self.mqtt_publisher: MqttClientInterface = mqtt_publisher
-        self.upload_queue: Queue = events.upload_queue
+        self.upload_task_event: Event[tuple[InspectionTask, Mission]] = (
+            events.robot_service_events.request_inspection_upload
+        )
+        self.upload_inspection_event: Event[tuple[Inspection, Mission]] = (
+            events.upload_event
+        )
+        self.uploader: Uploader = uploader
         self.robot: RobotInterface = robot
         self.upload_inspection_threads: list[FunctionThread] = []
         self.signal_exit: ThreadEvent = ThreadEvent()
@@ -107,7 +97,7 @@ class RobotInspectionService:
 
     def register_and_monitor_inspection_callback(
         self,
-        callback_function: Callable,
+        callback_function: Callable[[Inspection, Mission], None],
     ) -> None:
         self.inspection_callback_function = callback_function
 
@@ -121,18 +111,33 @@ class RobotInspectionService:
     def run(self) -> None:
         try:
             while not self.signal_exit.wait(0):
-                upload_request: tuple[(InspectionTask, Mission)] | None = (
-                    self.robot_service_events.request_inspection_upload.consume_event()
+
+                upload_task_request: tuple[(InspectionTask, Mission)] | None = (
+                    self.upload_task_event.consume_event()
                 )
-                if upload_request is not None:
+
+                if upload_task_request is not None:
                     self.upload_inspection_threads.append(
                         FunctionThread(
-                            robot_upload_inspection,
-                            self.robot,
+                            fetch_and_upload_inspection,
+                            self.robot.get_inspection,
                             self.logger,
-                            upload_request[0],
-                            upload_request[1],
-                            self.upload_queue,
+                            self.uploader.upload_inspection,
+                            upload_task_request[0],
+                            upload_task_request[1],
+                        )
+                    )
+
+                upload_inspection_request: tuple[Inspection, Mission] | None = (
+                    self.upload_inspection_event.consume_event()
+                )
+
+                if upload_inspection_request is not None:
+                    self.upload_inspection_threads.append(
+                        FunctionThread(
+                            self.uploader.upload_inspection,
+                            upload_inspection_request[0],
+                            upload_inspection_request[1],
                         )
                     )
 

--- a/src/isar/script.py
+++ b/src/isar/script.py
@@ -10,7 +10,7 @@ from isar.apis.api import API
 from isar.config.log import setup_loggers
 from isar.config.open_telemetry import instrument_fastapi, setup_open_telemetry
 from isar.config.settings import robot_settings, settings
-from isar.models.events import Events, InspectionQueueTuple
+from isar.models.events import Events
 from isar.modules import ApplicationContainer, get_injector
 from isar.robot.robot_inspection_service import RobotInspectionService
 from isar.robot.robot_service import RobotService
@@ -22,7 +22,6 @@ from isar.services.service_connections.mqtt.robot_info_publisher import (
     RobotInfoPublisher,
 )
 from isar.state_machine.state_machine import StateMachine
-from isar.storage.uploader import Uploader
 from robot_interface.models.inspection.inspection import Inspection
 from robot_interface.models.mission.mission import Mission
 from robot_interface.robot_interface import RobotInterface
@@ -83,7 +82,6 @@ def start() -> None:
     print_startup_info()
 
     state_machine: StateMachine = injector.state_machine()
-    uploader: Uploader = injector.uploader()
     robot_interface: RobotInterface = injector.robot_interface()
     events: Events = injector.events()
     robot: RobotService = injector.robot()
@@ -110,12 +108,6 @@ def start() -> None:
     inspection_service_thread.start()
     threads.append(inspection_service_thread)
 
-    uploader_thread: Thread = Thread(
-        target=uploader.run, name="ISAR Uploader", daemon=True
-    )
-    uploader_thread.start()
-    threads.append(uploader_thread)
-
     robot_service_thread: Thread = Thread(
         target=robot.run, name="Robot service", daemon=True
     )
@@ -125,11 +117,7 @@ def start() -> None:
     if settings.UPLOAD_INSPECTIONS_ASYNC:
 
         def inspections_callback(inspection: Inspection, mission: Mission) -> None:
-            message: InspectionQueueTuple = (
-                inspection,
-                mission,
-            )
-            state_machine.events.upload_queue.put(message)
+            state_machine.events.upload_event.trigger_event((inspection, mission))
 
         inspection_service.register_and_monitor_inspection_callback(
             inspections_callback

--- a/src/isar/services/utilities/robot_utilities.py
+++ b/src/isar/services/utilities/robot_utilities.py
@@ -1,5 +1,3 @@
-import logging
-
 from robot_interface.models.robots.media import MediaConfig
 from robot_interface.robot_interface import RobotInterface
 
@@ -14,7 +12,6 @@ class RobotUtilities:
         robot: RobotInterface,
     ):
         self.robot: RobotInterface = robot
-        self.logger = logging.getLogger("api")
 
     def generate_media_config(self) -> MediaConfig | None:
         return self.robot.generate_media_config()

--- a/src/isar/storage/uploader.py
+++ b/src/isar/storage/uploader.py
@@ -1,11 +1,7 @@
 import logging
-from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
-from queue import Empty, Queue, ShutDown
-from threading import Event
+import time
 
 from isar.config.settings import settings
-from isar.models.events import Events, InspectionQueueTuple
 from isar.services.service_connections.mqtt.mqtt_client import props_expiry
 from isar.storage.storage_interface import (
     BlobStoragePath,
@@ -35,254 +31,153 @@ def has_empty_blob_storage_path(storage_paths: StoragePaths) -> bool:
     return False
 
 
-@dataclass
-class UploaderQueueItem:
-    inspection: Inspection
-    mission: Mission
-
-
-@dataclass
-class ValueItem(UploaderQueueItem):
-    inspection: InspectionValue
-
-
-@dataclass
-class BlobItem(UploaderQueueItem):
-    inspection: InspectionBlob
-    storage_handler: StorageInterface
-    _retry_count: int
-    _next_retry_time: datetime = field(default_factory=lambda: datetime.now(UTC))
-
-    def increment_retry(self, max_wait_time: int) -> None:
-        self._retry_count += 1
-        seconds_until_retry: int = min(2**self._retry_count, max_wait_time)
-        self._next_retry_time = datetime.now(UTC) + timedelta(
-            seconds=seconds_until_retry
-        )
-
-    def get_retry_count(self) -> int:
-        return self._retry_count
-
-    def is_ready_for_upload(self) -> bool:
-        return datetime.now(UTC) >= self._next_retry_time
-
-    def seconds_until_retry(self) -> int:
-        return max(0, int((self._next_retry_time - datetime.now(UTC)).total_seconds()))
-
-
 class Uploader:
     def __init__(
         self,
-        events: Events,
         storage_handlers: list[StorageInterface],
         mqtt_publisher: MqttClientInterface,
-        max_wait_time: int = settings.UPLOAD_FAILURE_MAX_WAIT,
-        max_retry_attempts: int = settings.UPLOAD_FAILURE_ATTEMPTS_LIMIT,
     ) -> None:
         """Initializes the uploader.
 
         Parameters
         ----------
-        events : Events
-            Events used for cross-thread communication.
         storage_handlers : List[StorageInterface]
             List of handlers for different upload options
-        max_wait_time : float
-            The maximum wait time between two retries (exponential backoff)
-        max_retry_attempts : int
-            Maximum attempts to retry an upload when it fails
+        mqtt_publisher : MqttClientInterface
+            The client used to publish results to MQTT
         """
-        self.upload_queue: Queue[InspectionQueueTuple] = events.upload_queue
         self.storage_handlers: list[StorageInterface] = storage_handlers
         self.mqtt_publisher = mqtt_publisher
-
-        self.max_wait_time = max_wait_time
-        self.max_retry_attempts = max_retry_attempts
-        self._internal_upload_queue: list[UploaderQueueItem] = []
-
-        self.signal_exit: Event = Event()
-
         self.logger = logging.getLogger("uploader")
 
-    def stop(self) -> None:
-        self.signal_exit.set()
+    def upload_inspection(self, inspection: Inspection, mission: Mission) -> None:
+        if isinstance(inspection, InspectionValue):
+            _publish_inspection_value(self.mqtt_publisher, inspection)
+            self.logger.info(f"Published value for inspection {str(inspection.id)[:8]}")
 
-    def run(self) -> None:
-        self.logger.info("Started uploader")
-        while not self.signal_exit.wait(0):
-            inspection: Inspection
-            mission: Mission
-            try:
-                if self._internal_upload_queue:
-                    self._process_upload_queue()
+        elif isinstance(inspection, InspectionBlob):
+            for storage_handler in self.storage_handlers:
+                inspection_paths: StoragePaths | None = _upload(
+                    self.logger, storage_handler, inspection, mission
+                )
 
-                inspection, mission = self.upload_queue.get(timeout=1)
-
-                if not mission:
-                    self.logger.warning(
-                        "Failed to upload missing mission from upload queue"
-                    )
+                if inspection_paths is None:
                     continue
 
-                new_item: UploaderQueueItem
-                if isinstance(inspection, InspectionValue):
-                    new_item = ValueItem(inspection, mission)
-                    self._internal_upload_queue.append(new_item)
-
-                elif isinstance(inspection, InspectionBlob):
-                    # If new item from thread queue, add one per handler to internal queue:
-                    for storage_handler in self.storage_handlers:
-                        new_item = BlobItem(
-                            inspection, mission, storage_handler, _retry_count=-1
-                        )
-                        self._internal_upload_queue.append(new_item)
-                else:
+                if isinstance(inspection_paths.data_path, LocalStoragePath):
+                    self.logger.info("Skipping publishing when using local storage")
+                elif isinstance(
+                    inspection_paths.data_path, BlobStoragePath
+                ) and has_empty_blob_storage_path(inspection_paths):
                     self.logger.warning(
-                        f"Unable to add UploaderQueueItem as its type {type(inspection).__name__} is unsupported"
+                        "Skipping publishing: Blob storage paths are empty for inspection %s",
+                        str(inspection.id)[:8],
                     )
-            except Empty:
-                continue
-            except (ShutDown, ValueError) as e:
-                self.logger.error(
-                    f"Unexpected event queue error in uploader thread: {e}"
-                )
-                continue
+                else:
+                    _publish_inspection_result(
+                        self.mqtt_publisher,
+                        inspection=inspection,
+                        inspection_paths=inspection_paths,
+                        mission=mission,
+                    )
 
-    def _upload(self, item: BlobItem) -> StoragePaths:
-        inspection_paths: StoragePaths
-        try:
-            inspection_paths = item.storage_handler.store(
-                inspection=item.inspection, mission=item.mission
-            )
-            self.logger.info(
-                f"Storage handler: {type(item.storage_handler).__name__} "
-                f"uploaded inspection {str(item.inspection.id)[:8]}"
-            )
-            self._internal_upload_queue.remove(item)
-        except StorageException:
-            if item.get_retry_count() < self.max_retry_attempts:
-                item.increment_retry(self.max_wait_time)
-                self.logger.warning(
-                    f"Storage handler: {type(item.storage_handler).__name__} "
-                    f"failed to upload inspection: "
-                    f"{str(item.inspection.id)[:8]}. "
-                    f"Retrying in {item.seconds_until_retry()}s."
-                )
-            else:
-                self.logger.error(
-                    f"Storage handler: {type(item.storage_handler).__name__} "
-                    f"exceeded max retries to upload inspection: "
-                    f"{str(item.inspection.id)[:8]}. Aborting upload."
-                )
-                self._internal_upload_queue.remove(item)
-            raise
-        return inspection_paths
-
-    def _process_upload_queue(self) -> None:
-        def should_upload(_item: UploaderQueueItem) -> bool:
-            if isinstance(_item, ValueItem):
-                return True
-            if isinstance(_item, BlobItem) and _item.is_ready_for_upload():
-                return True
-            return False
-
-        ready_items: list[UploaderQueueItem] = [
-            item for item in self._internal_upload_queue if should_upload(item)
-        ]
-        for item in ready_items:
-            if isinstance(item, ValueItem):
-                self._publish_inspection_value(item.inspection)
-                self.logger.info(
-                    f"Published value for inspection {str(item.inspection.id)[:8]}"
-                )
-                self._internal_upload_queue.remove(item)
-            elif isinstance(item, BlobItem):
-                try:
-                    inspection_paths = self._upload(item)
-                    if isinstance(inspection_paths.data_path, LocalStoragePath):
-                        self.logger.info("Skipping publishing when using local storage")
-                    elif isinstance(
-                        inspection_paths.data_path, BlobStoragePath
-                    ) and has_empty_blob_storage_path(inspection_paths):
-                        self.logger.warning(
-                            "Skipping publishing: Blob storage paths are empty for inspection %s",
-                            str(item.inspection.id)[:8],
-                        )
-                    else:
-                        self._publish_inspection_result(
-                            inspection=item.inspection,
-                            inspection_paths=inspection_paths,
-                            mission=item.mission,
-                        )
-                except StorageException:
-                    pass
-            else:
-                self.logger.warning(
-                    f"Unable to process upload item as its type {type(item).__name__} is not supported"
-                )
-
-    def _publish_inspection_value(self, inspection: InspectionValue) -> None:
-        if not self.mqtt_publisher:
-            return
-
-        if not isinstance(inspection, InspectionValue):
+        else:
             self.logger.warning(
-                f"Excpected type InspectionValue but got {type(inspection).__name__} instead"
+                f"Unable to add upload item as its type {type(inspection).__name__} is unsupported"
             )
-            return
 
-        payload: InspectionValuePayload = InspectionValuePayload(
-            isar_id=settings.ISAR_ID,
-            robot_name=settings.ROBOT_NAME,
-            inspection_id=inspection.id,
-            installation_code=settings.PLANT_SHORT_NAME,
-            tag_id=inspection.metadata.tag_id,
-            inspection_type=type(inspection).__name__,
-            inspection_description=inspection.metadata.inspection_description,
-            value=inspection.value,
-            unit=inspection.unit,
-            x=inspection.metadata.robot_pose.position.x,
-            y=inspection.metadata.robot_pose.position.y,
-            z=inspection.metadata.robot_pose.position.z,
-            timestamp=inspection.metadata.start_time,
-        )
-        self.mqtt_publisher.publish(
-            topic=settings.TOPIC_ISAR_INSPECTION_VALUE,
-            payload=payload.model_dump_json(),
-            qos=1,
-            retain=True,
-            properties=props_expiry(settings.MQTT_MISSION_TASK_AND_STATUS_EXPIRY),
-        )
 
-    def _publish_inspection_result(
-        self,
-        inspection: InspectionBlob,
-        inspection_paths: StoragePaths[BlobStoragePath],
-        mission: Mission,
-    ) -> None:
-        if not self.mqtt_publisher:
-            return
+def _upload(
+    logger: logging.Logger,
+    storage_handler: StorageInterface,
+    inspection: Inspection,
+    mission: Mission,
+) -> StoragePaths | None:
+    inspection_paths: StoragePaths
+    upload_attempts: int = 0
+    while upload_attempts < settings.UPLOAD_FAILURE_ATTEMPTS_LIMIT:
+        try:
+            inspection_paths = storage_handler.store(
+                inspection=inspection, mission=mission
+            )
+            logger.info(
+                f"Storage handler: {type(storage_handler).__name__} "
+                f"uploaded inspection {str(inspection.id)[:8]}"
+            )
+            return inspection_paths
+        except StorageException:
+            upload_attempts += 1
 
-        payload: InspectionResultPayload = InspectionResultPayload(
-            isar_id=settings.ISAR_ID,
-            robot_name=settings.ROBOT_NAME,
-            inspection_id=inspection.id,
-            mission_id=mission.id,
-            blob_storage_data_path=inspection_paths.data_path,
-            blob_storage_metadata_path=inspection_paths.metadata_path,
-            installation_code=settings.PLANT_SHORT_NAME,
-            tag_id=inspection.metadata.tag_id,
-            inspection_type=type(inspection).__name__,
-            inspection_description=inspection.metadata.inspection_description,
-            required_analysis=inspection.metadata.analysis_types,
-            timestamp=inspection.metadata.start_time,
-            robot_pose=inspection.metadata.robot_pose,
-            target_position=inspection.metadata.target_position,
-        )
-        self.mqtt_publisher.publish(
-            topic=settings.TOPIC_ISAR_INSPECTION_RESULT,
-            payload=payload.model_dump_json(),
-            qos=1,
-            retain=True,
-            properties=props_expiry(settings.MQTT_MISSION_TASK_AND_STATUS_EXPIRY),
-        )
+            if upload_attempts < settings.UPLOAD_FAILURE_ATTEMPTS_LIMIT:
+                sleep_length = min(2**upload_attempts, settings.UPLOAD_FAILURE_MAX_WAIT)
+                logger.warning(
+                    f"Storage handler: {type(storage_handler).__name__} "
+                    f"failed to upload inspection: "
+                    f"{str(inspection.id)[:8]}. "
+                    f"Retrying in {sleep_length}s."
+                )
+                time.sleep(sleep_length)
+    logger.error(
+        f"Storage handler: {type(storage_handler).__name__} "
+        f"exceeded max retries to upload inspection: "
+        f"{str(inspection.id)[:8]}. Aborting upload."
+    )
+    return None
+
+
+def _publish_inspection_value(
+    mqtt_publisher: MqttClientInterface, inspection: InspectionValue
+) -> None:
+    payload: InspectionValuePayload = InspectionValuePayload(
+        isar_id=settings.ISAR_ID,
+        robot_name=settings.ROBOT_NAME,
+        inspection_id=inspection.id,
+        installation_code=settings.PLANT_SHORT_NAME,
+        tag_id=inspection.metadata.tag_id,
+        inspection_type=type(inspection).__name__,
+        inspection_description=inspection.metadata.inspection_description,
+        value=inspection.value,
+        unit=inspection.unit,
+        x=inspection.metadata.robot_pose.position.x,
+        y=inspection.metadata.robot_pose.position.y,
+        z=inspection.metadata.robot_pose.position.z,
+        timestamp=inspection.metadata.start_time,
+    )
+    mqtt_publisher.publish(
+        topic=settings.TOPIC_ISAR_INSPECTION_VALUE,
+        payload=payload.model_dump_json(),
+        qos=1,
+        retain=True,
+        properties=props_expiry(settings.MQTT_MISSION_TASK_AND_STATUS_EXPIRY),
+    )
+
+
+def _publish_inspection_result(
+    mqtt_publisher: MqttClientInterface,
+    inspection: InspectionBlob,
+    inspection_paths: StoragePaths[BlobStoragePath],
+    mission: Mission,
+) -> None:
+    payload: InspectionResultPayload = InspectionResultPayload(
+        isar_id=settings.ISAR_ID,
+        robot_name=settings.ROBOT_NAME,
+        inspection_id=inspection.id,
+        mission_id=mission.id,
+        blob_storage_data_path=inspection_paths.data_path,
+        blob_storage_metadata_path=inspection_paths.metadata_path,
+        installation_code=settings.PLANT_SHORT_NAME,
+        tag_id=inspection.metadata.tag_id,
+        inspection_type=type(inspection).__name__,
+        inspection_description=inspection.metadata.inspection_description,
+        required_analysis=inspection.metadata.analysis_types,
+        timestamp=inspection.metadata.start_time,
+        robot_pose=inspection.metadata.robot_pose,
+        target_position=inspection.metadata.target_position,
+    )
+    mqtt_publisher.publish(
+        topic=settings.TOPIC_ISAR_INSPECTION_RESULT,
+        payload=payload.model_dump_json(),
+        qos=1,
+        retain=True,
+        properties=props_expiry(settings.MQTT_MISSION_TASK_AND_STATUS_EXPIRY),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,6 @@ from tests.test_mocks.robot_interface import StubRobot
 from tests.test_mocks.state_machine_mocks import (
     RobotServiceThreadMock,
     StateMachineThreadMock,
-    UploaderThreadMock,
 )
 
 
@@ -66,7 +65,6 @@ def container() -> ApplicationContainer:
     container.uploader.override(
         providers.Singleton(
             Uploader,
-            container.events(),
             container.storage_handlers(),
             container.mqtt_client(),
         )
@@ -152,6 +150,12 @@ def robot() -> StubRobot:
 
 
 @pytest.fixture()
+def uploader(container: ApplicationContainer) -> Uploader:
+    """Fixture to provide a mock robot instance."""
+    return container.uploader()
+
+
+@pytest.fixture()
 def scheduling_utilities(
     container: ApplicationContainer,
 ) -> SchedulingUtilities:
@@ -195,15 +199,6 @@ def state_machine_thread_with_db(
 
 
 @pytest.fixture
-def uploader_thread(
-    container: ApplicationContainer,
-) -> Generator[UploaderThreadMock]:
-    uploader_thread: UploaderThreadMock = UploaderThreadMock(container=container)
-    yield uploader_thread
-    uploader_thread.join()
-
-
-@pytest.fixture
 def robot_service_thread(
     container: ApplicationContainer,
 ) -> Generator[RobotServiceThreadMock]:
@@ -227,7 +222,7 @@ def robot_inspection_service_thread(
     robot_inspection_service: RobotInspectionService = RobotInspectionService(
         events=container.events(),
         robot=container.robot_interface(),
-        mqtt_publisher=container.mqtt_client(),
+        uploader=container.uploader(),
     )
 
     robot_inspection_service_thread: Thread = Thread(

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -18,7 +18,6 @@ from tests.test_mocks.robot_interface import StubRobot
 from tests.test_mocks.state_machine_mocks import (
     RobotServiceThreadMock,
     StateMachineThreadMock,
-    UploaderThreadMock,
 )
 from tests.test_mocks.task import StubTask
 from tests.wait import wait_until
@@ -28,7 +27,6 @@ def test_state_machine_with_successful_mission_stop(
     container: ApplicationContainer,
     robot_service_thread: RobotServiceThreadMock,
     state_machine_thread: StateMachineThreadMock,
-    uploader_thread: UploaderThreadMock,
     mocker: MockerFixture,
 ) -> None:
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
@@ -51,7 +49,6 @@ def test_state_machine_with_successful_mission_stop(
 
     state_machine_thread.start()
     robot_service_thread.start()
-    uploader_thread.start()
     wait_until(
         lambda: States.Home in state_machine_thread.state_machine.transitions_list
     )

--- a/tests/isar/state_machine/test_integration_test_for_states.py
+++ b/tests/isar/state_machine/test_integration_test_for_states.py
@@ -21,7 +21,6 @@ from tests.test_mocks.robot_interface import (
 from tests.test_mocks.state_machine_mocks import (
     RobotServiceThreadMock,
     StateMachineThreadMock,
-    UploaderThreadMock,
 )
 from tests.test_mocks.task import StubTask
 from tests.wait import wait_until
@@ -138,7 +137,6 @@ def test_state_machine_with_successful_collection(
     container: ApplicationContainer,
     state_machine_thread: StateMachineThreadMock,
     robot_service_thread: RobotServiceThreadMock,
-    uploader_thread: UploaderThreadMock,
     robot_inspection_service_thread: Thread,
     mocker: MockerFixture,
 ) -> None:
@@ -159,7 +157,6 @@ def test_state_machine_with_successful_collection(
 
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 2.0)
     state_machine_thread.start()
-    uploader_thread.start()
 
     robot_service_thread.start()
     wait_until(
@@ -190,7 +187,6 @@ def test_state_machine_with_unsuccessful_collection(
     mocker: MockerFixture,
     state_machine_thread: StateMachineThreadMock,
     robot_service_thread: RobotServiceThreadMock,
-    uploader_thread: UploaderThreadMock,
 ) -> None:
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
 
@@ -206,7 +202,6 @@ def test_state_machine_with_unsuccessful_collection(
     mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
     state_machine_thread.start()
     robot_service_thread.start()
-    uploader_thread.start()
     wait_until(
         lambda: States.Home in state_machine_thread.state_machine.transitions_list
     )

--- a/tests/isar/storage/test_uploader.py
+++ b/tests/isar/storage/test_uploader.py
@@ -1,10 +1,10 @@
 import json
-import time
 from uuid import uuid4
 
 from alitra import Frame, Orientation, Pose, Position
+from pytest_mock import MockerFixture
 
-from isar.modules import ApplicationContainer
+from isar.config.settings import settings
 from isar.storage.uploader import Uploader
 from robot_interface.models.inspection.inspection import Inspection, InspectionBlob
 from robot_interface.models.mission.mission import Mission
@@ -12,17 +12,11 @@ from robot_interface.models.mission.task import TakeImage
 from tests.test_mocks.blob_storage import StorageEmptyBlobPathsFake, StorageFake
 from tests.test_mocks.inspection import stub_image_metadata
 from tests.test_mocks.mqtt_client import MqttPublisherFake
-from tests.test_mocks.state_machine_mocks import UploaderThreadMock
-from tests.wait import wait_until
 
 MISSION_ID = "some-mission-id"
 
 
-def test_should_upload_from_queue(
-    container: ApplicationContainer, uploader_thread: UploaderThreadMock
-) -> None:
-    uploader_thread.start()
-
+def test_should_upload_from_queue(uploader: Uploader) -> None:
     pose = Pose(
         position=Position(x=4, y=4, z=0, frame=Frame(name="asset")),
         orientation=Orientation(
@@ -44,60 +38,51 @@ def test_should_upload_from_queue(
     assert isinstance(mission.tasks[0], TakeImage)
     inspection = InspectionBlob(metadata=stub_image_metadata(), id=mission.tasks[0].id)
 
-    message: tuple[Inspection, Mission] = (
-        inspection,
-        mission,
-    )
-
-    uploader: Uploader = container.uploader()
     storage_handler: StorageFake = uploader.storage_handlers[0]  # type: ignore
 
-    uploader.upload_queue.put(message)
-    wait_until(lambda: inspection in storage_handler.stored_inspections)
+    uploader.upload_inspection(inspection, mission)
+    assert inspection in storage_handler.stored_inspections
 
 
 def test_should_retry_failed_upload_from_queue(
-    container: ApplicationContainer, uploader_thread: UploaderThreadMock
+    uploader: Uploader, mocker: MockerFixture
 ) -> None:
-    uploader_thread.start()
-
+    mocker.patch.object(settings, "UPLOAD_FAILURE_MAX_WAIT", 0.0001)
+    mocker.patch.object(settings, "UPLOAD_FAILURE_ATTEMPTS_LIMIT", 4)
     INSPECTION_ID = "123-456"
     inspection = InspectionBlob(metadata=stub_image_metadata(), id=INSPECTION_ID)
     mission: Mission = Mission(id="id", name="Dummy Mission")
 
-    message: tuple[Inspection, Mission] = (
-        inspection,
-        mission,
-    )
-
-    uploader: Uploader = container.uploader()
     storage_handler: StorageFake = uploader.storage_handlers[0]  # type: ignore
 
-    # Need it to fail so that it retries
-    storage_handler.will_fail = True
-    uploader.upload_queue.put(message)
-    # Fixed wait: asserting absence of upload requires a real elapsed window
-    time.sleep(1)
+    storage_handler.failure_count = 3
+    uploader.upload_inspection(inspection, mission)
 
-    # Should not upload, instead raise StorageException
-    assert not storage_handler.blob_exists(inspection)
-    storage_handler.will_fail = False
-
-    # Retry succeeds once exponential backoff elapses
-    wait_until(lambda: storage_handler.blob_exists(inspection), timeout=5.0)
+    assert storage_handler.blob_exists(inspection)
 
 
-def test_should_not_publish_when_blob_paths_are_empty(
-    container: ApplicationContainer, uploader_thread: UploaderThreadMock
+def test_should_eventually_give_up_failed_upload_from_queue(
+    uploader: Uploader, mocker: MockerFixture
 ) -> None:
-    uploader_thread.start()
+    mocker.patch.object(settings, "UPLOAD_FAILURE_MAX_WAIT", 0.0001)
+    mocker.patch.object(settings, "UPLOAD_FAILURE_ATTEMPTS_LIMIT", 3)
+    INSPECTION_ID = "123-456"
+    inspection = InspectionBlob(metadata=stub_image_metadata(), id=INSPECTION_ID)
+    mission: Mission = Mission(id="id", name="Dummy Mission")
 
+    storage_handler: StorageFake = uploader.storage_handlers[0]  # type: ignore
+
+    storage_handler.failure_count = 5
+    uploader.upload_inspection(inspection, mission)
+
+    assert not storage_handler.blob_exists(inspection)
+
+
+def test_should_not_publish_when_blob_paths_are_empty(uploader: Uploader) -> None:
     mission: Mission = Mission(id="id", name="Dummy mission")
     inspection: Inspection = InspectionBlob(
         metadata=stub_image_metadata(), id="blob-empty"
     )
-
-    uploader: Uploader = container.uploader()
 
     storage_handler: StorageEmptyBlobPathsFake() = StorageEmptyBlobPathsFake()  # type: ignore
     uploader.storage_handlers[0] = storage_handler
@@ -105,20 +90,14 @@ def test_should_not_publish_when_blob_paths_are_empty(
     mqtt_fake = MqttPublisherFake()
     uploader.mqtt_publisher = mqtt_fake
 
-    message: tuple[Inspection, Mission] = (
-        inspection,
-        mission,
-    )
-    uploader.upload_queue.put(message)
-    wait_until(lambda: inspection in storage_handler.stored)
+    uploader.upload_inspection(inspection, mission)
+    assert inspection in storage_handler.stored
 
-    # Brief quiet period to confirm no MQTT publish follows the store
-    time.sleep(0.1)
     assert len(mqtt_fake.published) == 0
 
 
 def _put_inspection_with_analysis_types(
-    container: ApplicationContainer,
+    uploader: Uploader,
     analysis_types: list[str] | None,
 ) -> MqttPublisherFake:
     inspection = InspectionBlob(
@@ -126,34 +105,26 @@ def _put_inspection_with_analysis_types(
     )
     mission = Mission(id="id", name="m")
 
-    uploader: Uploader = container.uploader()
     mqtt_fake = MqttPublisherFake()
     uploader.mqtt_publisher = mqtt_fake
 
-    message: tuple[Inspection, Mission] = (inspection, mission)
-    uploader.upload_queue.put(message)
+    uploader.upload_inspection(inspection, mission)
     return mqtt_fake
 
 
-def test_publishes_required_analysis_when_present(
-    container: ApplicationContainer, uploader_thread: UploaderThreadMock
-) -> None:
-    uploader_thread.start()
+def test_publishes_required_analysis_when_present(uploader: Uploader) -> None:
     mqtt_fake = _put_inspection_with_analysis_types(
-        container, ["anonymize", "thermal-reading"]
+        uploader, ["anonymize", "thermal-reading"]
     )
-    wait_until(lambda: mqtt_fake.count() == 1)
+    assert mqtt_fake.count() == 1
 
     payload = json.loads(mqtt_fake.last()["payload"])
     assert payload["required_analysis"] == ["anonymize", "thermal-reading"]
 
 
-def test_publishes_null_required_analysis_when_absent(
-    container: ApplicationContainer, uploader_thread: UploaderThreadMock
-) -> None:
-    uploader_thread.start()
-    mqtt_fake = _put_inspection_with_analysis_types(container, None)
-    wait_until(lambda: mqtt_fake.count() == 1)
+def test_publishes_null_required_analysis_when_absent(uploader: Uploader) -> None:
+    mqtt_fake = _put_inspection_with_analysis_types(uploader, None)
+    assert mqtt_fake.count() == 1
 
     payload = json.loads(mqtt_fake.last()["payload"])
     assert payload["required_analysis"] is None

--- a/tests/test_mocks/blob_storage.py
+++ b/tests/test_mocks/blob_storage.py
@@ -9,7 +9,7 @@ from robot_interface.models.mission.mission import Mission
 
 
 class StorageFake(StorageInterface):
-    will_fail: bool = False
+    failure_count: int = 0
 
     def __init__(self) -> None:
         self.stored_inspections: list[Inspection] = []
@@ -17,7 +17,8 @@ class StorageFake(StorageInterface):
     def store(
         self, inspection: InspectionBlob, mission: Mission
     ) -> StoragePaths[BlobStoragePath]:
-        if self.will_fail:
+        if self.failure_count > 1:
+            self.failure_count -= 1
             raise StorageException("Fake failed on purpose")
         self.stored_inspections.append(inspection)
         path = BlobStoragePath(

--- a/tests/test_mocks/state_machine_mocks.py
+++ b/tests/test_mocks/state_machine_mocks.py
@@ -3,7 +3,6 @@ from threading import Thread
 from isar.modules import ApplicationContainer
 from isar.robot.robot_service import RobotService
 from isar.state_machine.state_machine import StateMachine
-from isar.storage.uploader import Uploader
 
 
 class StateMachineThreadMock:
@@ -16,19 +15,6 @@ class StateMachineThreadMock:
 
     def join(self) -> None:
         self.state_machine.terminate()
-        self._thread.join()
-
-
-class UploaderThreadMock:
-    def __init__(self, container: ApplicationContainer) -> None:
-        self.uploader: Uploader = container.uploader()
-        self._thread: Thread = Thread(target=self.uploader.run)
-
-    def start(self) -> None:
-        self._thread.start()
-
-    def join(self) -> None:
-        self.uploader.stop()
         self._thread.join()
 
 


### PR DESCRIPTION
There are two ways to receive inspection data, either by querying the robot, or via a callback function provided on the robot interface.

For the former, we would create an event when we were monitoring the mission and saw that a task completed. This event would then be read in the robot inspection service thread, which would create one thread per such request, which would fetch the inspection data from the robot interface, then put it on the queue which the uploader thread used. The uploader thread would then check this queue, wrap the data in some temporary data structure, then add it to another queue which it would check constantly within the same thread, retrying to upload as needed.

For the latter, the callback function would be registered within its own thread within the robot inspection service. In that thread the output of the callback function would be placed directly on the queue used by the uploader thread.

In this new system we keep the robot inspection service, but get rid of the uploader thread. The uploader is kept as a module, since it is convenient to be able to do dependency injection, but it can be used as an uploader function with some nice wrappers. When we get an event about a task completing when monitoring the mission, the robot service thread creates one thread which reads the inspection data from the robot interface, and creates an inspection data event. The callback function for the async inspection data creates this inspection data event directly. The robot inspection service also reads these events, and creates one thread per such event which does the same thing the uploader thread used to do, but for one inspection event at a time.

This not only simplifies the number of thread types we have, and the number of places they are created, but also simplifies the uploader module in such a way that we can test it synchronously, in deterministic unit tests.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.