### PR TITLE
Auto test valid API states

### DIFF
--- a/src/isar/apis/schedule/scheduling_controller.py
+++ b/src/isar/apis/schedule/scheduling_controller.py
@@ -17,7 +17,6 @@ from isar.apis.models.start_mission_definition import (
 )
 from isar.config.settings import robot_settings
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
-from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.task import TASKS
 
@@ -54,9 +53,6 @@ class SchedulingController:
                 detail=error_message_no_mission_definition,
             )
 
-        state: States = self.scheduling_utilities.get_state()
-        self.scheduling_utilities.verify_state_machine_ready_to_receive_mission(state)
-
         try:
             mission: Mission = to_isar_mission(
                 start_mission_definition=mission_definition
@@ -81,31 +77,11 @@ class SchedulingController:
     def return_home(self) -> None:
         self.logger.info("Received request to return home")
 
-        state: States = self.scheduling_utilities.get_state()
-        self.scheduling_utilities.verify_state_machine_ready_to_receive_return_home_mission(
-            state
-        )
-
         self.scheduling_utilities.return_home()
 
     @tracer.start_as_current_span("pause_mission")
     def pause_mission(self) -> ControlMissionResponse:
         self.logger.info("Received request to pause current mission")
-
-        state: States = self.scheduling_utilities.get_state()
-
-        if state not in [
-            States.Monitor,
-            States.ReturningHome,
-        ]:
-            error_message = (
-                f"Conflict - Pause command received in invalid state - State: {state}"
-            )
-            self.logger.warning(error_message)
-            raise HTTPException(
-                status_code=HTTPStatus.CONFLICT,
-                detail=error_message,
-            )
 
         pause_mission_response: ControlMissionResponse = (
             self.scheduling_utilities.pause_mission()
@@ -115,15 +91,6 @@ class SchedulingController:
     @tracer.start_as_current_span("resume_mission")
     def resume_mission(self) -> ControlMissionResponse:
         self.logger.info("Received request to resume current mission")
-
-        state: States = self.scheduling_utilities.get_state()
-
-        if state not in [States.Paused, States.ReturnHomePaused]:
-            error_message = (
-                f"Conflict - Resume command received in invalid state - State: {state}"
-            )
-            self.logger.warning(error_message)
-            raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
 
         resume_mission_response: ControlMissionResponse = (
             self.scheduling_utilities.resume_mission()
@@ -143,25 +110,6 @@ class SchedulingController:
 
         self.logger.info("Received request to stop current mission")
 
-        state: States = self.scheduling_utilities.get_state()
-
-        if (
-            state == States.UnknownStatus
-            or state == States.Stopping
-            or state == States.Offline
-            or state == States.Home
-            or state == States.ReturningHome
-            or state == States.GoingToLockdown
-            or state == States.GoingToRecharging
-            or state == States.Recharging
-            or state == States.Maintenance
-        ):
-            error_message = (
-                f"Conflict - Stop command received in invalid state - State: {state}"
-            )
-            self.logger.warning(error_message)
-            raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
-
         stop_mission_response: ControlMissionResponse = (
             self.scheduling_utilities.stop_mission(
                 mission_id.mission_id if mission_id.mission_id else ""
@@ -173,32 +121,12 @@ class SchedulingController:
     def release_intervention_needed(self) -> None:
         self.logger.info("Received request to release intervention needed state")
 
-        state: States = self.scheduling_utilities.get_state()
-
-        if state != States.InterventionNeeded:
-            error_message = f"Conflict - Release intervention needed command received in invalid state - State: {state}"
-            self.logger.warning(error_message)
-            raise HTTPException(
-                status_code=HTTPStatus.CONFLICT,
-                detail=error_message,
-            )
-
         self.scheduling_utilities.release_intervention_needed()
         self.logger.info("Released intervention needed state successfully")
 
     @tracer.start_as_current_span("lockdown")
     def lockdown(self) -> None:
         self.logger.info("Received request to lockdown robot")
-
-        state: States = self.scheduling_utilities.get_state()
-
-        if state == States.Lockdown:
-            error_message = "Conflict - Lockdown command received in lockdown state"
-            self.logger.warning(error_message)
-            raise HTTPException(
-                status_code=HTTPStatus.CONFLICT,
-                detail=error_message,
-            )
 
         self.scheduling_utilities.lock_down_robot()
         self.logger.info("Lockdown started successfully")
@@ -207,16 +135,6 @@ class SchedulingController:
     def release_lockdown(self) -> None:
         self.logger.info("Received request to release robot lockdown")
 
-        state: States = self.scheduling_utilities.get_state()
-
-        if state != States.Lockdown:
-            error_message = f"Conflict - Release lockdown command received in invalid state - State: {state}"
-            self.logger.warning(error_message)
-            raise HTTPException(
-                status_code=HTTPStatus.CONFLICT,
-                detail=error_message,
-            )
-
         self.scheduling_utilities.release_robot_lockdown()
         self.logger.info("Released lockdown successfully")
 
@@ -224,32 +142,12 @@ class SchedulingController:
     def set_maintenance_mode(self) -> None:
         self.logger.info("Received request to set maintenance_mode")
 
-        state: States = self.scheduling_utilities.get_state()
-
-        if state == States.Maintenance or state == States.StoppingDueToMaintenance:
-            message = f"Conflict - Call to set maintenance mode was given while in state {state}."
-            self.logger.info(message)
-            raise HTTPException(
-                status_code=HTTPStatus.CONFLICT,
-                detail=message,
-            )
-
         self.scheduling_utilities.set_maintenance_mode()
         self.logger.info("Maintenance mode has been set")
 
     @tracer.start_as_current_span("release_maintenance_mode")
     def release_maintenance_mode(self) -> None:
         self.logger.info("Received request to release robot from maintenance mode")
-
-        state: States = self.scheduling_utilities.get_state()
-
-        if state != States.Maintenance:
-            message = f"Conflict - Release maintenance mode command received in invalid state - State: {state}"
-            self.logger.info(message)
-            raise HTTPException(
-                status_code=HTTPStatus.CONFLICT,
-                detail=message,
-            )
 
         self.scheduling_utilities.release_maintenance_mode()
         self.logger.info("Maintenance mode successfully released")

--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -105,9 +105,14 @@ class APIEvent[T1, T2]:
     api to state machine while the response is from state machine to api.
     """
 
-    def __init__(self, name: str):
+    prioritized: bool
+
+    def __init__(self, name: str, prioritized: bool = False):
         self.request: Event[T1] = Event("api-" + name + "-request")
         self.response: Event[T2] = Event("api-" + name + "-request")
+        self.prioritized = (
+            prioritized  # For when we want to try even if the statemachine is not ready
+        )
         self.lock: Lock = Lock()
 
 
@@ -130,13 +135,13 @@ class APIRequests:
             APIEvent("release_intervention_needed")
         )
         self.send_to_lockdown: APIEvent[EmptyMessage, LockdownResponse] = APIEvent(
-            "send_to_lockdown"
+            "send_to_lockdown", prioritized=True
         )
         self.release_from_lockdown: APIEvent[EmptyMessage, EmptyMessage] = APIEvent(
             "release_from_lockdown"
         )
         self.set_maintenance_mode: APIEvent[EmptyMessage, MaintenanceResponse] = (
-            APIEvent("set_maintenance_mode")
+            APIEvent("set_maintenance_mode", prioritized=True)
         )
         self.release_from_maintenance_mode: APIEvent[EmptyMessage, EmptyMessage] = (
             APIEvent("release_from_maintenance_mode")

--- a/src/isar/modules.py
+++ b/src/isar/modules.py
@@ -39,11 +39,19 @@ class ApplicationContainer(containers.DeclarativeContainer):
         mqtt_queue=providers.Callable(events.provided.mqtt_queue),
     )
 
+    # State machine
+    state_machine = providers.Singleton(
+        StateMachine,
+        events=events,
+        mqtt_publisher=mqtt_client,
+    )
+
     # API and controllers
     authenticator = providers.Singleton(Authenticator)
     scheduling_utilities = providers.Singleton(
         SchedulingUtilities,
         events=events,
+        state_machine=state_machine,
     )
     scheduling_controller = providers.Singleton(
         SchedulingController, scheduling_utilities=scheduling_utilities
@@ -68,13 +76,6 @@ class ApplicationContainer(containers.DeclarativeContainer):
         blob_storage = providers.Singleton(BlobStorage)
         storage_handlers_temp.append(blob_storage)
     storage_handlers = providers.List(*storage_handlers_temp)
-
-    # State machine
-    state_machine = providers.Singleton(
-        StateMachine,
-        events=events,
-        mqtt_publisher=mqtt_client,
-    )
 
     # Robot
     robot = providers.Singleton(

--- a/src/isar/services/utilities/scheduling_utilities.py
+++ b/src/isar/services/utilities/scheduling_utilities.py
@@ -11,12 +11,11 @@ from isar.models.events import (
     APIEvent,
     APIRequests,
     EmptyMessage,
-    Event,
     EventConflictError,
     Events,
     EventTimeoutError,
 )
-from isar.state_machine.states_enum import States
+from isar.state_machine.state_machine import StateMachine
 from robot_interface.models.mission.mission import Mission
 
 T1 = TypeVar("T1")
@@ -32,29 +31,11 @@ class SchedulingUtilities:
     def __init__(
         self,
         events: Events,
+        state_machine: StateMachine,
     ):
         self.api_events: APIRequests = events.api_requests
-        self.state_event: Event[States] = events.state
+        self.state_machine: StateMachine = state_machine
         self.logger = logging.getLogger("api")
-
-    def get_state(self) -> States:
-        """Return the current state of the state machine
-
-        Raises
-        ------
-        HTTPException 500 Internal Server Error
-            If the current state is not available on the queue
-        """
-        current_state = self.state_event.check()
-        if current_state is None:
-            error_message: str = (
-                "Internal Server Error - Current state of the state machine is unknown"
-            )
-            self.logger.error(error_message)
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
-            )
-        return current_state
 
     def verify_robot_capable_of_mission(
         self, mission: Mission, robot_capabilities: list[str]
@@ -82,45 +63,6 @@ class SchedulingUtilities:
             )
 
         return True
-
-    def verify_state_machine_ready_to_receive_mission(self, state: States) -> bool:
-        """Verify that the state machine is ready to receive a mission
-
-        Raises
-        ------
-        HTTPException 409 Conflict
-            If state machine is not home, robot standing still, awaiting next mission
-            return home paused or returning home and therefore cannot start a new mission
-        """
-        if (
-            state == States.Home
-            or state == States.AwaitNextMission
-            or state == States.ReturningHome
-            or state == States.ReturnHomePaused
-        ):
-            return True
-
-        error_message = f"Conflict - Robot is not home, robot standing still, awaiting next mission or returning home - State: {state}"
-        self.logger.warning(error_message)
-        raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
-
-    def verify_state_machine_ready_to_receive_return_home_mission(
-        self, state: States
-    ) -> bool:
-        """Verify that the state machine is ready to receive a return home mission
-
-        Raises
-        ------
-        HTTPException 409 Conflict
-            If state machine is not home, robot standing still or awaiting next mission
-            and therefore cannot start a new return home mission
-        """
-        if state == States.Home or state == States.AwaitNextMission:
-            return True
-
-        error_message = f"Conflict - Robot is not home, robot standing still or awaiting next mission - State: {state}"
-        self.logger.warning(error_message)
-        raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
 
     def log_mission_overview(self, mission: Mission) -> None:
         """Log an overview of the tasks in a mission"""
@@ -433,7 +375,20 @@ class SchedulingUtilities:
             self.logger.warning(error_message)
             raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
 
+    def _verify_valid_state(self, api_event: APIEvent) -> None:
+        if (
+            not api_event.prioritized
+            and not self.state_machine.current_state_handles_event(api_event.request)
+        ):
+            error_message = (
+                "Conflict - Robot is not in a state where it can handle the request"
+            )
+            self.logger.warning(error_message)
+            raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
+
     def _send_command(self, input: T1, api_event: APIEvent[T1, T2]) -> T2:
+        self._verify_valid_state(api_event)
+
         if not api_event.lock.acquire(blocking=False):
             raise EventConflictError("API event has already been sent")
 

--- a/src/isar/state_machine/state.py
+++ b/src/isar/state_machine/state.py
@@ -64,6 +64,10 @@ class State(ABC):
         )
         return filtered_timers[0] if len(filtered_timers) > 0 else None
 
+    def handles_event(self, event: Event) -> bool:
+        allowed_events: list[Event] = [m.event for m in self.event_handler_mappings]
+        return event in allowed_events
+
     def run(self) -> Transition | None:
         timers = deepcopy(self.timers)
         entered_time = time.time()

--- a/src/isar/state_machine/state_machine.py
+++ b/src/isar/state_machine/state_machine.py
@@ -45,7 +45,7 @@ class StateMachine:
         self.state_event: Event[States] = events.state
         self.mqtt_publisher: MqttClientInterface | None = mqtt_publisher
 
-        self.starting_state: State = UnknownStatus(self.events)
+        self.current_state: State = UnknownStatus(self.events)
 
         if not settings.USE_DB:
             self.logger.warning(
@@ -57,28 +57,31 @@ class StateMachine:
                 f"Connected to robot status database and the startup mode was: {robot_startup_mode}. "
             )
             if robot_startup_mode == RobotStartupMode.Maintenance:
-                self.starting_state = Maintenance(self.events)
+                self.current_state = Maintenance(self.events)
             elif robot_startup_mode == RobotStartupMode.Lockdown:
-                self.starting_state = GoingToLockdown(self.events)
+                self.current_state = GoingToLockdown(self.events)
 
         self.transitions_list: deque[States] = deque(
             [], settings.STATE_TRANSITIONS_LOG_LENGTH
         )
 
-        self.state_event.update(self.starting_state.name)
+        self.state_event.update(self.current_state.name)
+
+        self.state_metrics_publisher: StateMetricsPublisher = StateMetricsPublisher(
+            current_state_provider=lambda: self.current_state.name
+        )
 
     #################################################################################
 
+    def current_state_handles_event(self, event: Event) -> bool:
+        return self.current_state.handles_event(event)
+
     def run(self) -> None:
         """Runs the state machine loop."""
-        current_state: State = self.starting_state
-        self.state_metrics_publisher: StateMetricsPublisher = StateMetricsPublisher(
-            current_state_provider=lambda: current_state.name
-        )
         try:
             while True:
-                self.update_state(current_state)
-                transition: Transition | None = current_state.run()
+                self.update_state(self.current_state)
+                transition: Transition | None = self.current_state.run()
 
                 if transition is None:  # Expected when the thread is killed
                     self.logger.warning(
@@ -86,7 +89,7 @@ class StateMachine:
                     )
                     break
 
-                current_state = transition(self.events)
+                self.current_state = transition(self.events)
         except Exception as e:  # noqa: BLE001
             self.logger.error(f"Unhandled exception in state machine: {str(e)}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,13 @@ def container() -> ApplicationContainer:
             mqtt_publisher=container.mqtt_client(),
         )
     )
+    container.state_machine.override(
+        providers.Singleton(
+            StateMachine,
+            events=container.events,
+            mqtt_publisher=container.mqtt_client(),
+        )
+    )
     return container
 
 
@@ -133,15 +140,9 @@ def events(container: ApplicationContainer) -> Events:
 
 
 @pytest.fixture()
-def state_machine(
-    container: ApplicationContainer, mocker: MockerFixture
-) -> StateMachine:
+def state_machine(container: ApplicationContainer) -> StateMachine:
     """Fixture to provide the StateMachine instance."""
-    mocker.patch.object(settings, "USE_DB", False)
-    return StateMachine(
-        events=container.events(),
-        mqtt_publisher=container.mqtt_client(),
-    )
+    return container.state_machine()
 
 
 @pytest.fixture()
@@ -155,7 +156,10 @@ def scheduling_utilities(
     container: ApplicationContainer,
 ) -> SchedulingUtilities:
     """Fixture to provide the SchedulingUtilities instance."""
-    return container.scheduling_utilities()
+    return SchedulingUtilities(
+        events=container.events(),
+        state_machine=container.state_machine(),
+    )
 
 
 @pytest.fixture

--- a/tests/isar/apis/scheduler/test_scheduler_router.py
+++ b/tests/isar/apis/scheduler/test_scheduler_router.py
@@ -4,10 +4,9 @@ from typing import ClassVar
 from unittest import mock
 from uuid import uuid4
 
-import pytest
+from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 from fastapi.testclient import TestClient
-from pytest_mock import MockerFixture
 
 from isar.apis.models.models import ControlMissionResponse
 from isar.apis.models.start_mission_definition import StopMissionDefinition
@@ -60,7 +59,9 @@ class TestStartMission:
         "mission_definition": DummyMissionDefinition.dummy_start_mission_definition_image_and_thermal
     }
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_home)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(SchedulingUtilities, "start_mission", mock_void)
     def test_start_mission(self, client: TestClient) -> None:
         response = client.post(
@@ -73,7 +74,11 @@ class TestStartMission:
         response = client.post(url=self.schedule_start_mission_path, json={})
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_monitor)
+    @mock.patch.object(
+        SchedulingUtilities,
+        "_verify_valid_state",
+        mock.Mock(side_effect=HTTPException(status_code=HTTPStatus.CONFLICT)),
+    )
     def test_state_machine_in_conflicting_state(self, client: TestClient) -> None:
         response = client.post(
             url=self.schedule_start_mission_path,
@@ -81,7 +86,9 @@ class TestStartMission:
         )
         assert response.status_code == HTTPStatus.CONFLICT
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_home)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(SchedulingUtilities, "_send_command", mock_queue_timeout_error)
     def test_start_mission_timeout(self, client: TestClient) -> None:
         response = client.post(
@@ -93,7 +100,9 @@ class TestStartMission:
             "detail": "State machine has entered a state which cannot start a mission"
         }
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_home)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch("isar.config.settings.robot_settings.CAPABILITIES", [])
     @mock.patch.object(SchedulingUtilities, "start_mission", mock_void)
     def test_robot_not_capable(self, client: TestClient) -> None:
@@ -115,7 +124,9 @@ class TestStartMission:
 class TestPauseMission:
     schedule_pause_mission_path = "/schedule/pause-mission"
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_monitor)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(
         SchedulingUtilities, "_send_command", mock_return_control_mission_response
     )
@@ -124,12 +135,9 @@ class TestPauseMission:
         assert response.status_code == HTTPStatus.OK
         assert response.json() == jsonable_encoder(dummy_control_mission_response)
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_home)
-    def test_state_machine_in_conflicting_state(self, client: TestClient) -> None:
-        response = client.post(url=self.schedule_pause_mission_path)
-        assert response.status_code == HTTPStatus.CONFLICT
-
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_monitor)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(SchedulingUtilities, "_send_command", mock_queue_timeout_error)
     def test_pause_mission_timeout(self, client: TestClient) -> None:
         response = client.post(url=self.schedule_pause_mission_path)
@@ -142,7 +150,9 @@ class TestPauseMission:
 class TestResumeMission:
     schedule_resume_mission_path = "/schedule/resume-mission"
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_paused)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(
         SchedulingUtilities, "_send_command", mock_return_control_mission_response
     )
@@ -151,12 +161,9 @@ class TestResumeMission:
         assert response.status_code == HTTPStatus.OK
         assert response.json() == jsonable_encoder(dummy_control_mission_response)
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_home)
-    def test_state_machine_in_conflicting_state(self, client: TestClient) -> None:
-        response = client.post(url=self.schedule_resume_mission_path)
-        assert response.status_code == HTTPStatus.CONFLICT
-
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_paused)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(SchedulingUtilities, "_send_command", mock_queue_timeout_error)
     def test_resume_mission_timeout(self, client: TestClient) -> None:
         response = client.post(url=self.schedule_resume_mission_path)
@@ -168,22 +175,19 @@ class TestResumeMission:
 
 class TestStopMission:
     schedule_stop_mission_path = "/schedule/stop-mission"
-    valid_states: ClassVar[list] = [
-        States.AwaitNextMission,
-        States.Monitor,
-        States.Paused,
-    ]
 
-    @pytest.mark.parametrize("state", valid_states)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(
         SchedulingUtilities,
         "_send_command",
         mock_return_stopped_control_mission_response,
     )
     def test_stop_mission(
-        self, client: TestClient, state: States, mocker: MockerFixture
+        self,
+        client: TestClient,
     ) -> None:
-        mocker.patch.object(SchedulingUtilities, "get_state", return_value=state)
         response = client.post(
             url=self.schedule_stop_mission_path,
             json=jsonable_encoder({"mission_id": StopMissionDefinition(mission_id="")}),
@@ -193,15 +197,9 @@ class TestStopMission:
             dummy_stopped_control_mission_response
         )
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_unknown_status)
     @mock.patch.object(
-        SchedulingUtilities, "stop_mission", dummy_control_mission_response
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
     )
-    def test_can_not_stop_mission_in_unknown_status(self, client: TestClient) -> None:
-        response = client.post(url=self.schedule_stop_mission_path)
-        assert response.status_code == HTTPStatus.CONFLICT
-
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_monitor)
     @mock.patch.object(SchedulingUtilities, "_send_command", mock_queue_timeout_error)
     def test_stop_mission_timeout(self, client: TestClient) -> None:
         response = client.post(
@@ -210,7 +208,9 @@ class TestStopMission:
         )
         assert response.status_code == HTTPStatus.CONFLICT
 
-    @mock.patch.object(SchedulingUtilities, "get_state", mock_return_monitor)
+    @mock.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     @mock.patch.object(
         SchedulingUtilities,
         "_send_command",

--- a/tests/isar/services/utilities/test_scheduling_utilities.py
+++ b/tests/isar/services/utilities/test_scheduling_utilities.py
@@ -10,7 +10,42 @@ from isar.config.settings import settings
 from isar.models.events import APIEvent, Event, EventTimeoutError
 from isar.modules import ApplicationContainer
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
+from isar.state_machine.states.await_next_mission import AwaitNextMission
+from isar.state_machine.states.going_to_lockdown import GoingToLockdown
+from isar.state_machine.states.going_to_recharging import GoingToRecharging
+from isar.state_machine.states.going_to_recharging_with_mission import (
+    GoingToRechargingWithMission,
+)
+from isar.state_machine.states.home import Home
+from isar.state_machine.states.intervention_needed import InterventionNeeded
+from isar.state_machine.states.lockdown import Lockdown
+from isar.state_machine.states.maintenance import Maintenance
+from isar.state_machine.states.monitor import Monitor
+from isar.state_machine.states.offline import Offline
+from isar.state_machine.states.paused import Paused
+from isar.state_machine.states.pausing import Pausing
+from isar.state_machine.states.pausing_return_home import PausingReturnHome
+from isar.state_machine.states.recharging import Recharging
+from isar.state_machine.states.recharging_with_mission import RechargingWithMission
+from isar.state_machine.states.resuming import Resuming
+from isar.state_machine.states.resuming_return_home import ResumingReturnHome
+from isar.state_machine.states.return_home_paused import ReturnHomePaused
+from isar.state_machine.states.returning_home import ReturningHome
+from isar.state_machine.states.stopping import Stopping
+from isar.state_machine.states.stopping_due_to_maintenance import (
+    StoppingDueToMaintenance,
+)
+from isar.state_machine.states.stopping_go_to_lockdown import StoppingGoToLockdown
+from isar.state_machine.states.stopping_go_to_recharge import StoppingGoToRecharge
+from isar.state_machine.states.stopping_paused_mission import StoppingPausedMission
+from isar.state_machine.states.stopping_paused_return_home import (
+    StoppingPausedReturnHome,
+)
+from isar.state_machine.states.stopping_return_home import StoppingReturnHome
+from isar.state_machine.states.stopping_unknown_mission import StoppingUnknownMission
+from isar.state_machine.states.unknown_status import UnknownStatus
 from isar.state_machine.states_enum import States
+from robot_interface.models.mission.mission import Mission
 from tests.test_mocks.mission_definition import DummyMissionDefinition
 
 
@@ -19,6 +54,9 @@ def test_timeout_send_command(
 ) -> None:
     mocker.patch.object(settings, "QUEUE_TIMEOUT", 2)
     mocker.patch.object(Event, "consume_event", side_effect=EventTimeoutError)
+    mocker.patch.object(
+        SchedulingUtilities, "_verify_valid_state", lambda self, event: None
+    )
     q: APIEvent = APIEvent("test")
     with pytest.raises(EventTimeoutError):
         scheduling_utilities._send_command(True, q)
@@ -45,26 +83,101 @@ def test_robot_not_capable_of_mission(
 
 def test_state_machine_ready_to_receive_mission(
     scheduling_utilities: SchedulingUtilities,
+    mocker: MockerFixture,
 ) -> None:
-    assert scheduling_utilities.verify_state_machine_ready_to_receive_mission(
-        States.Home
-    )
-    assert scheduling_utilities.verify_state_machine_ready_to_receive_mission(
-        States.ReturningHome
-    )
-    assert scheduling_utilities.verify_state_machine_ready_to_receive_mission(
-        States.AwaitNextMission
-    )
+    events = scheduling_utilities.state_machine.events
+    api_events = events.api_requests
 
+    mission = Mission(id="", tasks=[], name="")
 
-def test_state_machine_not_ready_to_receive_mission(
-    scheduling_utilities: SchedulingUtilities,
-) -> None:
-    with pytest.raises(HTTPException) as err:
-        scheduling_utilities.verify_state_machine_ready_to_receive_mission(
-            States.Monitor
-        )
-    assert err.value.status_code == HTTPStatus.CONFLICT
+    states = {
+        States.Monitor: Monitor(events, ""),
+        States.ReturningHome: ReturningHome(events),
+        States.Stopping: Stopping(events, ""),
+        States.StoppingUnknownMission: StoppingUnknownMission(events),
+        States.StoppingReturnHome: StoppingReturnHome(events, mission),
+        States.Paused: Paused(events, ""),
+        States.Pausing: Pausing(events, ""),
+        States.Resuming: Resuming(events, ""),
+        States.PausingReturnHome: PausingReturnHome(events),
+        States.ResumingReturnHome: ResumingReturnHome(events),
+        States.ReturnHomePaused: ReturnHomePaused(events),
+        States.AwaitNextMission: AwaitNextMission(events),
+        States.Home: Home(events),
+        States.Offline: Offline(events),
+        States.UnknownStatus: UnknownStatus(events),
+        States.InterventionNeeded: InterventionNeeded(events),
+        States.Recharging: Recharging(events),
+        States.RechargingWithMission: RechargingWithMission(events, mission),
+        States.StoppingGoToLockdown: StoppingGoToLockdown(events, ""),
+        States.GoingToLockdown: GoingToLockdown(events),
+        States.Lockdown: Lockdown(events),
+        States.GoingToRecharging: GoingToRecharging(events),
+        States.GoingToRechargingWithMission: GoingToRechargingWithMission(
+            events, mission
+        ),
+        States.StoppingGoToRecharge: StoppingGoToRecharge(events),
+        States.Maintenance: Maintenance(events),
+        States.StoppingDueToMaintenance: StoppingDueToMaintenance(events),
+        States.StoppingPausedMission: StoppingPausedMission(events, ""),
+        States.StoppingPausedReturnHome: StoppingPausedReturnHome(events, mission),
+    }
+
+    all_states = list(states.keys())
+
+    event_mappings: dict[APIEvent, list[States]] = {
+        api_events.start_mission: [
+            States.Home,
+            States.AwaitNextMission,
+            States.ReturningHome,
+            States.ReturnHomePaused,
+        ],
+        api_events.stop_mission: [
+            States.Monitor,
+            States.GoingToRechargingWithMission,
+            States.RechargingWithMission,
+            States.AwaitNextMission,
+            States.Paused,
+            States.Home,
+            States.UnknownStatus,
+        ],
+        api_events.pause_mission: [States.Monitor, States.ReturningHome],
+        api_events.resume_mission: [States.Paused, States.ReturnHomePaused],
+        api_events.send_to_lockdown: all_states,
+        api_events.release_from_lockdown: [States.Lockdown],
+        api_events.set_maintenance_mode: all_states,
+        api_events.release_from_maintenance_mode: [States.Maintenance],
+        api_events.release_intervention_needed: [States.InterventionNeeded],
+        api_events.return_home: [
+            States.AwaitNextMission,
+            States.Home,
+            States.InterventionNeeded,
+        ],
+    }
+
+    for event, valid_states in event_mappings.items():
+        mocker.patch.object(event.request, "trigger_event", lambda input, timeout: None)
+        mocker.patch.object(event.response, "consume_event", lambda timeout: None)
+        for state_name, state_object in states.items():
+            scheduling_utilities.state_machine.current_state = state_object
+            if state_name in valid_states:
+                try:
+                    scheduling_utilities._send_command(True, event)
+                except HTTPException:
+                    assert (
+                        False
+                    ), f"Failed to send event {event.request.name} in state {state_name}"
+            else:
+                try:
+                    scheduling_utilities._send_command(True, event)
+                    pytest.fail(
+                        f"Event {event.request.name} succeeded in state {state_name}"
+                    )
+                except Exception as e:  # noqa: BLE001
+                    assert (
+                        e.__class__ == HTTPException
+                    ), f"Event {event.request.name} failed in state {state_name} with an incorrect exception type {e.__class__}"
+    assert True
 
 
 def test_mission_already_started_causes_conflict(

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -153,8 +153,9 @@ def test_state_machine_with_unsuccessful_mission_stop(
     state_machine_thread.start()
     robot_service_thread.start()
     wait_until(
-        lambda: States.UnknownStatus
-        in state_machine_thread.state_machine.transitions_list
+        lambda: States.AwaitNextMission
+        in state_machine_thread.state_machine.transitions_list,
+        timeout=10,
     )
     scheduling_utilities.start_mission(mission=mission)
     wait_until(
@@ -203,6 +204,12 @@ def test_state_machine_with_unsuccessful_mission_stop_with_mission_id(
     state_machine_thread.start()
     robot_service_thread.start()
 
+    wait_until(
+        lambda: States.AwaitNextMission
+        in state_machine_thread.state_machine.transitions_list,
+        timeout=10,
+    )
+
     scheduling_utilities.start_mission(mission=mission)
     wait_until(
         lambda: state_machine_thread.state_machine.state_event.check() == States.Monitor
@@ -236,6 +243,12 @@ def test_robot_mission_status_exception_handling(
 
     state_machine_thread.start()
     robot_service_thread.start()
+
+    wait_until(
+        lambda: States.AwaitNextMission
+        in state_machine_thread.state_machine.transitions_list,
+        timeout=10,
+    )
 
     scheduling_utilities.start_mission(mission=mission)
 

--- a/tests/isar/state_machine/test_integration_test_for_states.py
+++ b/tests/isar/state_machine/test_integration_test_for_states.py
@@ -33,15 +33,16 @@ def test_state_machine_transitions_when_running_full_mission(
     robot_service_thread: RobotServiceThreadMock,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
+    mocker.patch.object(settings, "RETURN_HOME_DELAY", 5.0)
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
 
     state_machine_thread.start()
     robot_service_thread.start()
     wait_until(
-        lambda: States.UnknownStatus
+        lambda: States.AwaitNextMission
         in state_machine_thread.state_machine.transitions_list
-        and robot_service_thread.robot_service.status_thread is not None
+        and robot_service_thread.robot_service.status_thread is not None,
+        timeout=10,
     )
     # Setting the poll interval to a lower value to ensure that the robot status is
     # updated during the mission. This value needs to be set after the robot service
@@ -76,7 +77,8 @@ def test_state_machine_transitions_when_running_full_mission(
     )
     wait_until(
         lambda: state_machine_thread.state_machine.transitions_list
-        == expected_transitions
+        == expected_transitions,
+        timeout=15.0,
     )
 
 
@@ -86,7 +88,7 @@ def test_state_machine_failed_dependency(
     robot_service_thread: RobotServiceThreadMock,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
+    mocker.patch.object(settings, "RETURN_HOME_DELAY", 5.0)
     mocker.patch.object(settings, "RETURN_HOME_RETRY_LIMIT", 3)
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
 
@@ -104,8 +106,9 @@ def test_state_machine_failed_dependency(
     state_machine_thread.start()
     robot_service_thread.start()
     wait_until(
-        lambda: States.UnknownStatus
-        in state_machine_thread.state_machine.transitions_list
+        lambda: States.AwaitNextMission
+        in state_machine_thread.state_machine.transitions_list,
+        timeout=10,
     )
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
@@ -154,14 +157,14 @@ def test_state_machine_with_successful_collection(
     )
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
 
-    mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
+    mocker.patch.object(settings, "RETURN_HOME_DELAY", 2.0)
     state_machine_thread.start()
     uploader_thread.start()
 
     robot_service_thread.start()
     wait_until(
-        lambda: States.UnknownStatus
-        in state_machine_thread.state_machine.transitions_list
+        lambda: States.Home in state_machine_thread.state_machine.transitions_list,
+        timeout=10,
     )
     scheduling_utilities.start_mission(mission=mission)
 
@@ -254,8 +257,8 @@ def test_state_machine_with_mission_start_during_return_home_without_queueing_st
     state_machine_thread.start()
     robot_service_thread.start()
     wait_until(
-        lambda: States.UnknownStatus
-        in state_machine_thread.state_machine.transitions_list
+        lambda: States.Home in state_machine_thread.state_machine.transitions_list,
+        timeout=10,
     )
     scheduling_utilities.return_home()
     wait_until(
@@ -289,7 +292,7 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
 ) -> None:
     mocker.patch.object(settings, "ROBOT_API_BATTERY_POLL_INTERVAL", 0.01)
     mocker.patch.object(settings, "FSM_SLEEP_TIME", 0.01)
-    mocker.patch.object(settings, "RETURN_HOME_DELAY", 0.01)
+    mocker.patch.object(settings, "RETURN_HOME_DELAY", 10.0)
 
     robot_service_thread.robot_service.robot = StubRobotInitiateMissionRaisesException()
 
@@ -306,9 +309,11 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
 
     # TODO: check mqtt
     wait_until(
-        lambda: States.UnknownStatus
-        in state_machine_thread.state_machine.transitions_list
+        lambda: States.AwaitNextMission
+        in state_machine_thread.state_machine.transitions_list,
+        timeout=10,
     )
+
     scheduling_utilities: SchedulingUtilities = container.scheduling_utilities()
     scheduling_utilities.start_mission(mission=mission)
 
@@ -329,12 +334,11 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
     wait_until(
         lambda: state_machine_thread.state_machine.transitions_list
         == expected_transitions,
-        timeout=10.0,
+        timeout=20.0,
     )
 
 
 def test_state_machine_battery_too_low_to_start_mission(
-    container: ApplicationContainer,
     state_machine_thread: StateMachineThreadMock,
     robot_service_thread: RobotServiceThreadMock,
     mocker: MockerFixture,

--- a/tests/test_persistent_memory.py
+++ b/tests/test_persistent_memory.py
@@ -63,8 +63,8 @@ def test_persistent_storage_schema() -> None:
 
 
 def test_lockdown_mode(
-    client: TestClient,
     state_machine_thread_with_db: StateMachineThreadMock,
+    client: TestClient,
     robot_service_thread: RobotServiceThreadMock,
     mocker: MockerFixture,
 ) -> None:
@@ -154,8 +154,8 @@ def test_lockdown_mode(
 
 
 def test_maintenance_mode(
-    client: TestClient,
     state_machine_thread_with_db: StateMachineThreadMock,
+    client: TestClient,
     robot_service_thread: RobotServiceThreadMock,
     mocker: MockerFixture,
 ) -> None:
@@ -240,8 +240,8 @@ def test_maintenance_mode(
 
 
 def test_release_maintenance_mode(
-    client: TestClient,
     state_machine_thread_with_db: StateMachineThreadMock,
+    client: TestClient,
     robot_service_thread: RobotServiceThreadMock,
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
Instead of relying on people manually setting which state the robot can accept API requests in, this PR does it automatically and tests based on a specification.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.