### PR TITLE
Simplify state machine framework

### DIFF
--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -191,7 +191,7 @@ class RobotServiceEvents:
         self.battery_below_mission_threshold: Event[EmptyMessage] = Event(
             "battery_below_mission_threshold"
         )
-        self.battery_above_recharge_threshold_event: Event[EmptyMessage] = Event(
+        self.battery_above_recharge_threshold: Event[EmptyMessage] = Event(
             "battery_above_recharge_threshold"
         )
 

--- a/src/isar/robot/robot_service.py
+++ b/src/isar/robot/robot_service.py
@@ -193,7 +193,7 @@ class RobotService:
             self.robot,
             self.signal_exit,
             self.robot_service_events.battery_below_mission_threshold,
-            self.robot_service_events.battery_above_recharge_threshold_event,
+            self.robot_service_events.battery_above_recharge_threshold,
         )
         self.battery_thread.start()
 

--- a/src/isar/state_machine/state.py
+++ b/src/isar/state_machine/state.py
@@ -16,7 +16,6 @@ Transition = Callable[[Events], T_state_co]
 
 @dataclass
 class EventHandlerMapping[T]:
-    name: str
     event: Event[T]
     handler: Callable[[T], Transition | None]
 
@@ -42,10 +41,10 @@ class State(ABC):
         self.event_handler_mappings = event_handler_mappings
         self.timers = timers if timers is not None else []
 
-    def get_event_handler_by_name(self, event_handler_name: str) -> EventHandlerMapping:
+    def get_event_handler_by_event(self, event: Event) -> EventHandlerMapping:
         filtered_handlers = list(
             filter(
-                lambda mapping: mapping.name == event_handler_name,
+                lambda mapping: mapping.event == event,
                 self.event_handler_mappings,
             )
         )
@@ -86,7 +85,7 @@ class State(ABC):
                 if event_value is not None:
                     transition = handler_mapping.handler(event_value)
                     self.logger.debug(
-                        f"Event '{handler_mapping.name}' triggered with input: {event_value}. "
+                        f"Event '{handler_mapping.event.name}' triggered with input: {event_value}. "
                     )
                     if transition is not None:
                         self.logger.debug(

--- a/src/isar/state_machine/state.py
+++ b/src/isar/state_machine/state.py
@@ -42,27 +42,25 @@ class State(ABC):
         self.event_handler_mappings = event_handler_mappings
         self.timers = timers if timers is not None else []
 
-    def get_event_handler_by_name(
-        self, event_handler_name: str
-    ) -> EventHandlerMapping | None:
+    def get_event_handler_by_name(self, event_handler_name: str) -> EventHandlerMapping:
         filtered_handlers = list(
             filter(
                 lambda mapping: mapping.name == event_handler_name,
                 self.event_handler_mappings,
             )
         )
-        return filtered_handlers[0] if len(filtered_handlers) > 0 else None
+        assert len(filtered_handlers) > 0
+        return filtered_handlers[0]
 
-    def get_event_timer_by_name(
-        self, event_timer_name: str
-    ) -> TimeoutHandlerMapping | None:
+    def get_event_timer_by_name(self, event_timer_name: str) -> TimeoutHandlerMapping:
         filtered_timers = list(
             filter(
                 lambda mapping: mapping.name == event_timer_name,
                 self.timers,
             )
         )
-        return filtered_timers[0] if len(filtered_timers) > 0 else None
+        assert len(filtered_timers) > 0
+        return filtered_timers[0]
 
     def handles_event(self, event: Event) -> bool:
         allowed_events: list[Event] = [m.event for m in self.event_handler_mappings]

--- a/src/isar/state_machine/state.py
+++ b/src/isar/state_machine/state.py
@@ -1,17 +1,15 @@
 import logging
 import time
-from abc import ABC
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any
 
 from isar.config.settings import settings
 from isar.models.events import EmptyMessage, Event, Events
 from isar.state_machine.states_enum import States
 
-T_state_co = TypeVar("T_state_co", bound="State", covariant=True)
-Transition = Callable[[Events], T_state_co]
+Transition = Callable[[Events], "State"]
 
 
 @dataclass
@@ -27,7 +25,7 @@ class TimeoutHandlerMapping:
     handler: Callable[[], Transition | None]
 
 
-class State(ABC):
+class State:
     def __init__(
         self,
         signal_exit_event: Event[EmptyMessage],

--- a/src/isar/state_machine/states/await_next_mission.py
+++ b/src/isar/state_machine/states/await_next_mission.py
@@ -29,7 +29,7 @@ class AwaitNextMission(State):
             ),
             EventHandlerMapping[EmptyMessage](
                 event=events.api_requests.return_home.request,
-                handler=lambda event: ReturningHome.transition_and_start_mission(True),
+                handler=lambda _: ReturningHome.transition_and_start_mission(True),
             ),
             EventHandlerMapping[str](
                 event=events.api_requests.stop_mission.request,

--- a/src/isar/state_machine/states/await_next_mission.py
+++ b/src/isar/state_machine/states/await_next_mission.py
@@ -16,59 +16,55 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 
 
-class AwaitNextMission(State):
+def AwaitNextMission(events: Events) -> State:
 
-    def __init__(self, events: Events):
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[Mission](
+            event=events.api_requests.start_mission.request,
+            handler=lambda mission: Monitor.transition_and_start_mission(mission, True),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.return_home.request,
+            handler=lambda _: ReturningHome.transition_and_start_mission(True),
+        ),
+        EventHandlerMapping[str](
+            event=events.api_requests.stop_mission.request,
+            handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
+                mission_id
+            ),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: GoingToLockdown.transition_and_start_mission_and_report_to_api(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_below_mission_threshold,
+            handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: Maintenance.transition_and_reply_to_API(),
+        ),
+    ]
 
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[Mission](
-                event=events.api_requests.start_mission.request,
-                handler=lambda mission: Monitor.transition_and_start_mission(
-                    mission, True
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.return_home.request,
-                handler=lambda _: ReturningHome.transition_and_start_mission(True),
-            ),
-            EventHandlerMapping[str](
-                event=events.api_requests.stop_mission.request,
-                handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
-                    mission_id
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: GoingToLockdown.transition_and_start_mission_and_report_to_api(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_below_mission_threshold,
-                handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: Maintenance.transition_and_reply_to_API(),
-            ),
-        ]
-
-        timers: list[TimeoutHandlerMapping] = [
-            TimeoutHandlerMapping(
-                name="should_return_home_timer",
-                timeout_in_seconds=settings.RETURN_HOME_DELAY,
-                handler=lambda: ReturningHome.transition_and_start_mission(),
-            )
-        ]
-
-        super().__init__(
-            state_name=States.AwaitNextMission,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-            timers=timers,
+    timers: list[TimeoutHandlerMapping] = [
+        TimeoutHandlerMapping(
+            name="should_return_home_timer",
+            timeout_in_seconds=settings.RETURN_HOME_DELAY,
+            handler=lambda: ReturningHome.transition_and_start_mission(),
         )
+    ]
+
+    return State(
+        state_name=States.AwaitNextMission,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+        timers=timers,
+    )
 
 
-def transition() -> Transition[AwaitNextMission]:
-    def _transition(events: Events) -> AwaitNextMission:
+def transition() -> Transition:
+    def _transition(events: Events) -> State:
         return AwaitNextMission(events)
 
     return _transition

--- a/src/isar/state_machine/states/await_next_mission.py
+++ b/src/isar/state_machine/states/await_next_mission.py
@@ -22,36 +22,30 @@ class AwaitNextMission(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[Mission](
-                name="start_mission_event",
                 event=events.api_requests.start_mission.request,
                 handler=lambda mission: Monitor.transition_and_start_mission(
                     mission, True
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="return_home_event",
                 event=events.api_requests.return_home.request,
                 handler=lambda event: ReturningHome.transition_and_start_mission(True),
             ),
             EventHandlerMapping[str](
-                name="stop_mission_event",
                 event=events.api_requests.stop_mission.request,
                 handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
                     mission_id
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: GoingToLockdown.transition_and_start_mission_and_report_to_api(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_below_threshold_event",
                 event=events.robot_service_events.battery_below_mission_threshold,
                 handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: Maintenance.transition_and_reply_to_API(),
             ),

--- a/src/isar/state_machine/states/going_to_lockdown.py
+++ b/src/isar/state_machine/states/going_to_lockdown.py
@@ -8,37 +8,33 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
 from robot_interface.models.mission.mission import ReturnHomeMission
 
 
-class GoingToLockdown(State):
+def GoingToLockdown(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[ErrorMessage](
-                event=events.robot_service_events.mission_failed,
-                handler=lambda _: InterventionNeeded.transition(
-                    "Lockdown mission failed"
-                ),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[ErrorMessage](
+            event=events.robot_service_events.mission_failed,
+            handler=lambda _: InterventionNeeded.transition("Lockdown mission failed"),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_resume,
+            handler=lambda _: InterventionNeeded.transition(
+                "Failed to resume return to home mission"
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_resume,
-                handler=lambda _: InterventionNeeded.transition(
-                    "Failed to resume return to home mission"
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_succeeded,
-                handler=lambda _: Lockdown.transition_without_responding_to_api(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.GoingToLockdown,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_succeeded,
+            handler=lambda _: Lockdown.transition_without_responding_to_api(),
+        ),
+    ]
+    return State(
+        state_name=States.GoingToLockdown,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition_and_start_mission_and_report_to_api() -> Transition[GoingToLockdown]:
-    def _transition(events: Events) -> GoingToLockdown:
+def transition_and_start_mission_and_report_to_api() -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.send_to_lockdown.response.trigger_event(
             LockdownResponse(lockdown_started=True)
         )
@@ -52,8 +48,8 @@ def transition_and_start_mission_and_report_to_api() -> Transition[GoingToLockdo
     return _transition
 
 
-def transition_to_existing_mission_and_report_to_api() -> Transition[GoingToLockdown]:
-    def _transition(events: Events) -> GoingToLockdown:
+def transition_to_existing_mission_and_report_to_api() -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.send_to_lockdown.response.trigger_event(
             LockdownResponse(lockdown_started=True)
         )

--- a/src/isar/state_machine/states/going_to_lockdown.py
+++ b/src/isar/state_machine/states/going_to_lockdown.py
@@ -14,21 +14,18 @@ class GoingToLockdown(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[ErrorMessage](
-                name="mission_failed_event",
                 event=events.robot_service_events.mission_failed,
                 handler=lambda _: InterventionNeeded.transition(
                     "Lockdown mission failed"
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_failed_to_resume",
                 event=events.robot_service_events.mission_failed_to_resume,
                 handler=lambda _: InterventionNeeded.transition(
                     "Failed to resume return to home mission"
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_succeeded_event",
                 event=events.robot_service_events.mission_succeeded,
                 handler=lambda _: Lockdown.transition_without_responding_to_api(),
             ),

--- a/src/isar/state_machine/states/going_to_recharging.py
+++ b/src/isar/state_machine/states/going_to_recharging.py
@@ -14,19 +14,16 @@ class GoingToRecharging(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[ErrorMessage](
-                name="mission_failed_event",
                 event=events.robot_service_events.mission_failed,
                 handler=lambda _: InterventionNeeded.transition(
                     "Return home to recharge failed"
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_succeeded_event",
                 event=events.robot_service_events.mission_succeeded,
                 handler=lambda _: Recharging.transition(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
             ),

--- a/src/isar/state_machine/states/going_to_recharging.py
+++ b/src/isar/state_machine/states/going_to_recharging.py
@@ -8,35 +8,33 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
 from robot_interface.models.mission.mission import ReturnHomeMission
 
 
-class GoingToRecharging(State):
+def GoingToRecharging(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[ErrorMessage](
-                event=events.robot_service_events.mission_failed,
-                handler=lambda _: InterventionNeeded.transition(
-                    "Return home to recharge failed"
-                ),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[ErrorMessage](
+            event=events.robot_service_events.mission_failed,
+            handler=lambda _: InterventionNeeded.transition(
+                "Return home to recharge failed"
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_succeeded,
-                handler=lambda _: Recharging.transition(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.GoingToRecharging,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_succeeded,
+            handler=lambda _: Recharging.transition(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
+        ),
+    ]
+    return State(
+        state_name=States.GoingToRecharging,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition_and_start_return_home() -> Transition[GoingToRecharging]:
-    def _transition(events: Events) -> GoingToRecharging:
+def transition_and_start_return_home() -> Transition:
+    def _transition(events: Events) -> State:
         events.robot_service_events.mission_failed.clear_event()
         events.robot_service_events.mission_succeeded.clear_event()
 
@@ -46,8 +44,8 @@ def transition_and_start_return_home() -> Transition[GoingToRecharging]:
     return _transition
 
 
-def transition_to_existing_mission() -> Transition[GoingToRecharging]:
-    def _transition(events: Events) -> GoingToRecharging:
+def transition_to_existing_mission() -> Transition:
+    def _transition(events: Events) -> State:
         return GoingToRecharging(events)
 
     return _transition

--- a/src/isar/state_machine/states/going_to_recharging_with_mission.py
+++ b/src/isar/state_machine/states/going_to_recharging_with_mission.py
@@ -12,66 +12,64 @@ from robot_interface.models.mission.mission import ReturnHomeMission
 from robot_interface.models.mission.status import MissionStatus
 
 
-class GoingToRechargingWithMission(State):
+def GoingToRechargingWithMission(events: Events, mission: AbortedMission) -> State:
 
-    def __init__(self, events: Events, mission: AbortedMission):
-
-        def _mission_failed_event_handler(
-            error_message: ErrorMessage,
-        ) -> Transition[InterventionNeeded.InterventionNeeded]:
-            publish_mission_status(
-                events.mqtt_queue,
-                mission.id,
-                MissionStatus.Failed,
-                error_message,
-            )
-            return InterventionNeeded.transition("Return home to recharge failed")
-
-        def _stop_mission_event_handler(
-            stop_mission_id: str,
-        ) -> Transition[GoingToRecharging.GoingToRecharging] | None:
-            if mission.id == stop_mission_id or stop_mission_id == "":
-                events.api_requests.stop_mission.response.trigger_event(
-                    ControlMissionResponse(success=True)
-                )
-                return GoingToRecharging.transition_to_existing_mission()
-            else:
-                events.api_requests.stop_mission.response.trigger_event(
-                    ControlMissionResponse(
-                        success=False, failure_reason="Mission not found"
-                    )
-                )
-                return None
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[ErrorMessage](
-                event=events.robot_service_events.mission_failed,
-                handler=_mission_failed_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_succeeded,
-                handler=lambda _: RechargingWithMission.transition(mission),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
-            ),
-            EventHandlerMapping[str](
-                event=events.api_requests.stop_mission.request,
-                handler=_stop_mission_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.GoingToRechargingWithMission,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def _mission_failed_event_handler(
+        error_message: ErrorMessage,
+    ) -> Transition:
+        publish_mission_status(
+            events.mqtt_queue,
+            mission.id,
+            MissionStatus.Failed,
+            error_message,
         )
+        return InterventionNeeded.transition("Return home to recharge failed")
+
+    def _stop_mission_event_handler(
+        stop_mission_id: str,
+    ) -> Transition | None:
+        if mission.id == stop_mission_id or stop_mission_id == "":
+            events.api_requests.stop_mission.response.trigger_event(
+                ControlMissionResponse(success=True)
+            )
+            return GoingToRecharging.transition_to_existing_mission()
+        else:
+            events.api_requests.stop_mission.response.trigger_event(
+                ControlMissionResponse(
+                    success=False, failure_reason="Mission not found"
+                )
+            )
+            return None
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[ErrorMessage](
+            event=events.robot_service_events.mission_failed,
+            handler=_mission_failed_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_succeeded,
+            handler=lambda _: RechargingWithMission.transition(mission),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
+        ),
+        EventHandlerMapping[str](
+            event=events.api_requests.stop_mission.request,
+            handler=_stop_mission_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.GoingToRechargingWithMission,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_start_return_home(
     mission: AbortedMission,
-) -> Transition[GoingToRechargingWithMission]:
-    def _transition(events: Events) -> GoingToRechargingWithMission:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.robot_service_events.mission_failed.clear_event()
         events.robot_service_events.mission_succeeded.clear_event()
 

--- a/src/isar/state_machine/states/going_to_recharging_with_mission.py
+++ b/src/isar/state_machine/states/going_to_recharging_with_mission.py
@@ -45,22 +45,18 @@ class GoingToRechargingWithMission(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[ErrorMessage](
-                name="mission_failed_event",
                 event=events.robot_service_events.mission_failed,
                 handler=_mission_failed_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_succeeded_event",
                 event=events.robot_service_events.mission_succeeded,
                 handler=lambda _: RechargingWithMission.transition(mission),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
             ),
             EventHandlerMapping[str](
-                name="stop_mission_event",
                 event=events.api_requests.stop_mission.request,
                 handler=_stop_mission_event_handler,
             ),

--- a/src/isar/state_machine/states/home.py
+++ b/src/isar/state_machine/states/home.py
@@ -30,23 +30,11 @@ class Home(State):
             if robot_status == RobotStatus.Home:
                 return None
             elif robot_status == RobotStatus.Available:
-                self.logger.info(
-                    "Got robot status available while in home state. Leaving home state."
-                )
                 return AwaitNextMission.transition()
             elif robot_status == RobotStatus.Offline:
-                self.logger.info(
-                    "Got robot status offline while in home state. Leaving home state."
-                )
                 return Offline.transition()
             elif robot_status == RobotStatus.TeleOperation:
-                self.logger.info(
-                    "Got robot status teleoperation while in home state. Going to maintenance."
-                )
                 return Maintenance.transition_without_replying_to_API()
-            self.logger.info(
-                f"Got unexpected status {robot_status} while in home state. Leaving home state."
-            )
             return UnknownStatus.transition()
 
         event_handlers: list[EventHandlerMapping] = [

--- a/src/isar/state_machine/states/home.py
+++ b/src/isar/state_machine/states/home.py
@@ -46,7 +46,7 @@ class Home(State):
             ),
             EventHandlerMapping[EmptyMessage](
                 event=events.api_requests.return_home.request,
-                handler=lambda event: ReturningHome.transition_and_start_mission(True),
+                handler=lambda _: ReturningHome.transition_and_start_mission(True),
             ),
             EventHandlerMapping[str](
                 event=events.api_requests.stop_mission.request,

--- a/src/isar/state_machine/states/home.py
+++ b/src/isar/state_machine/states/home.py
@@ -14,72 +14,62 @@ from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.status import RobotStatus
 
 
-class Home(State):
+def Home(events: Events) -> State:
 
-    def __init__(self, events: Events):
+    def _robot_status_event_handler(
+        robot_status: RobotStatus,
+    ) -> Transition | None:
+        if robot_status == RobotStatus.Home:
+            return None
+        elif robot_status == RobotStatus.Available:
+            return AwaitNextMission.transition()
+        elif robot_status == RobotStatus.Offline:
+            return Offline.transition()
+        elif robot_status == RobotStatus.TeleOperation:
+            return Maintenance.transition_without_replying_to_API()
+        return UnknownStatus.transition()
 
-        def _robot_status_event_handler(
-            robot_status: RobotStatus,
-        ) -> (
-            Transition[AwaitNextMission.AwaitNextMission]
-            | Transition[Offline.Offline]
-            | Transition[Maintenance.Maintenance]
-            | Transition[UnknownStatus.UnknownStatus]
-            | None
-        ):
-            if robot_status == RobotStatus.Home:
-                return None
-            elif robot_status == RobotStatus.Available:
-                return AwaitNextMission.transition()
-            elif robot_status == RobotStatus.Offline:
-                return Offline.transition()
-            elif robot_status == RobotStatus.TeleOperation:
-                return Maintenance.transition_without_replying_to_API()
-            return UnknownStatus.transition()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[Mission](
-                event=events.api_requests.start_mission.request,
-                handler=lambda mission: Monitor.transition_and_start_mission(
-                    mission, True
-                ),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[Mission](
+            event=events.api_requests.start_mission.request,
+            handler=lambda mission: Monitor.transition_and_start_mission(mission, True),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.return_home.request,
+            handler=lambda _: ReturningHome.transition_and_start_mission(True),
+        ),
+        EventHandlerMapping[str](
+            event=events.api_requests.stop_mission.request,
+            handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
+                mission_id
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.return_home.request,
-                handler=lambda _: ReturningHome.transition_and_start_mission(True),
-            ),
-            EventHandlerMapping[str](
-                event=events.api_requests.stop_mission.request,
-                handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
-                    mission_id
-                ),
-            ),
-            EventHandlerMapping[RobotStatus](
-                event=events.robot_service_events.robot_status_update,
-                handler=_robot_status_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: Lockdown.transition_and_respond_to_api(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_below_mission_threshold,
-                handler=lambda _: Recharging.transition(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: Maintenance.transition_and_reply_to_API(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.Home,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[RobotStatus](
+            event=events.robot_service_events.robot_status_update,
+            handler=_robot_status_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: Lockdown.transition_and_respond_to_api(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_below_mission_threshold,
+            handler=lambda _: Recharging.transition(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: Maintenance.transition_and_reply_to_API(),
+        ),
+    ]
+    return State(
+        state_name=States.Home,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition() -> Transition[Home]:
-    def _transition(events: Events) -> Home:
+def transition() -> Transition:
+    def _transition(events: Events) -> State:
         # This clears the current robot status value, so we don't read an outdated value
         events.robot_service_events.robot_status_update.clear_event()
 

--- a/src/isar/state_machine/states/home.py
+++ b/src/isar/state_machine/states/home.py
@@ -51,41 +51,34 @@ class Home(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[Mission](
-                name="start_mission_event",
                 event=events.api_requests.start_mission.request,
                 handler=lambda mission: Monitor.transition_and_start_mission(
                     mission, True
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="return_home_event",
                 event=events.api_requests.return_home.request,
                 handler=lambda event: ReturningHome.transition_and_start_mission(True),
             ),
             EventHandlerMapping[str](
-                name="stop_mission_event",
                 event=events.api_requests.stop_mission.request,
                 handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
                     mission_id
                 ),
             ),
             EventHandlerMapping[RobotStatus](
-                name="robot_status_event",
                 event=events.robot_service_events.robot_status_update,
                 handler=_robot_status_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: Lockdown.transition_and_respond_to_api(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_below_threshold_event",
                 event=events.robot_service_events.battery_below_mission_threshold,
                 handler=lambda _: Recharging.transition(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: Maintenance.transition_and_reply_to_API(),
             ),

--- a/src/isar/state_machine/states/intervention_needed.py
+++ b/src/isar/state_machine/states/intervention_needed.py
@@ -9,52 +9,50 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import RobotStatus
 
 
-class InterventionNeeded(State):
+def InterventionNeeded(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        def release_intervention_needed_handler(
-            _: EmptyMessage,
-        ) -> Transition[UnknownStatus.UnknownStatus]:
-            events.api_requests.release_intervention_needed.response.trigger_event(
-                EmptyMessage()
-            )
-            return UnknownStatus.transition()
-
-        def _robot_status_event_handler(
-            robot_status: RobotStatus,
-        ) -> Transition[Home.Home] | None:
-            if robot_status == RobotStatus.Home:
-                return Home.transition()
-            return None
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.return_home.request,
-                handler=lambda _: ReturningHome.transition_and_start_mission(True),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.release_intervention_needed.request,
-                handler=release_intervention_needed_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: Maintenance.transition_and_reply_to_API(),
-            ),
-            EventHandlerMapping[RobotStatus](
-                event=events.robot_service_events.robot_status_update,
-                handler=_robot_status_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.InterventionNeeded,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def release_intervention_needed_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        events.api_requests.release_intervention_needed.response.trigger_event(
+            EmptyMessage()
         )
+        return UnknownStatus.transition()
+
+    def _robot_status_event_handler(
+        robot_status: RobotStatus,
+    ) -> Transition | None:
+        if robot_status == RobotStatus.Home:
+            return Home.transition()
+        return None
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.return_home.request,
+            handler=lambda _: ReturningHome.transition_and_start_mission(True),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.release_intervention_needed.request,
+            handler=release_intervention_needed_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: Maintenance.transition_and_reply_to_API(),
+        ),
+        EventHandlerMapping[RobotStatus](
+            event=events.robot_service_events.robot_status_update,
+            handler=_robot_status_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.InterventionNeeded,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition(reason: str) -> Transition[InterventionNeeded]:
-    def _transition(events: Events) -> InterventionNeeded:
+def transition(reason: str) -> Transition:
+    def _transition(events: Events) -> State:
         publish_intervention_needed(events.mqtt_queue, error_message=reason)
 
         return InterventionNeeded(events)

--- a/src/isar/state_machine/states/intervention_needed.py
+++ b/src/isar/state_machine/states/intervention_needed.py
@@ -25,9 +25,6 @@ class InterventionNeeded(State):
             robot_status: RobotStatus,
         ) -> Transition[Home.Home] | None:
             if robot_status == RobotStatus.Home:
-                self.logger.info(
-                    "Got robot status home while in intervention needed state. Leaving intervention needed state."
-                )
                 return Home.transition()
             return None
 

--- a/src/isar/state_machine/states/intervention_needed.py
+++ b/src/isar/state_machine/states/intervention_needed.py
@@ -33,22 +33,18 @@ class InterventionNeeded(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="return_home_event",
                 event=events.api_requests.return_home.request,
                 handler=lambda event: ReturningHome.transition_and_start_mission(True),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="release_intervention_needed_event",
                 event=events.api_requests.release_intervention_needed.request,
                 handler=release_intervention_needed_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: Maintenance.transition_and_reply_to_API(),
             ),
             EventHandlerMapping[RobotStatus](
-                name="robot_status_event",
                 event=events.robot_service_events.robot_status_update,
                 handler=_robot_status_event_handler,
             ),

--- a/src/isar/state_machine/states/intervention_needed.py
+++ b/src/isar/state_machine/states/intervention_needed.py
@@ -14,7 +14,7 @@ class InterventionNeeded(State):
     def __init__(self, events: Events):
 
         def release_intervention_needed_handler(
-            should_release: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[UnknownStatus.UnknownStatus]:
             events.api_requests.release_intervention_needed.response.trigger_event(
                 EmptyMessage()
@@ -31,7 +31,7 @@ class InterventionNeeded(State):
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
                 event=events.api_requests.return_home.request,
-                handler=lambda event: ReturningHome.transition_and_start_mission(True),
+                handler=lambda _: ReturningHome.transition_and_start_mission(True),
             ),
             EventHandlerMapping[EmptyMessage](
                 event=events.api_requests.release_intervention_needed.request,

--- a/src/isar/state_machine/states/lockdown.py
+++ b/src/isar/state_machine/states/lockdown.py
@@ -5,41 +5,37 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class Lockdown(State):
+def Lockdown(events: Events) -> State:
 
-    def __init__(self, events: Events):
+    def _release_from_lockdown_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        events.api_requests.release_from_lockdown.response.trigger_event(EmptyMessage())
+        return Home.transition()
 
-        def _release_from_lockdown_handler(
-            _: EmptyMessage,
-        ) -> Transition[Home.Home]:
-            events.api_requests.release_from_lockdown.response.trigger_event(
-                EmptyMessage()
-            )
-            return Home.transition()
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.release_from_lockdown.request,
+            handler=_release_from_lockdown_handler,
+        ),
+    ]
 
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.release_from_lockdown.request,
-                handler=_release_from_lockdown_handler,
-            ),
-        ]
-
-        super().__init__(
-            state_name=States.Lockdown,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+    return State(
+        state_name=States.Lockdown,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition_without_responding_to_api() -> Transition[Lockdown]:
-    def _transition(events: Events) -> Lockdown:
+def transition_without_responding_to_api() -> Transition:
+    def _transition(events: Events) -> State:
         return Lockdown(events)
 
     return _transition
 
 
-def transition_and_respond_to_api() -> Transition[Lockdown]:
-    def _transition(events: Events) -> Lockdown:
+def transition_and_respond_to_api() -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.send_to_lockdown.response.trigger_event(
             LockdownResponse(lockdown_started=True)
         )

--- a/src/isar/state_machine/states/lockdown.py
+++ b/src/isar/state_machine/states/lockdown.py
@@ -10,7 +10,7 @@ class Lockdown(State):
     def __init__(self, events: Events):
 
         def _release_from_lockdown_handler(
-            should_release_from_lockdown: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[Home.Home]:
             events.api_requests.release_from_lockdown.response.trigger_event(
                 EmptyMessage()

--- a/src/isar/state_machine/states/lockdown.py
+++ b/src/isar/state_machine/states/lockdown.py
@@ -19,7 +19,6 @@ class Lockdown(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="release_from_lockdown",
                 event=events.api_requests.release_from_lockdown.request,
                 handler=_release_from_lockdown_handler,
             ),

--- a/src/isar/state_machine/states/maintenance.py
+++ b/src/isar/state_machine/states/maintenance.py
@@ -10,7 +10,7 @@ class Maintenance(State):
     def __init__(self, events: Events):
 
         def _release_from_maintenance_handler(
-            should_release_from_maintenance: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[UnknownStatus.UnknownStatus]:
             events.api_requests.release_from_maintenance_mode.response.trigger_event(
                 EmptyMessage()

--- a/src/isar/state_machine/states/maintenance.py
+++ b/src/isar/state_machine/states/maintenance.py
@@ -20,7 +20,6 @@ class Maintenance(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="release_from_maintenance",
                 event=events.api_requests.release_from_maintenance_mode.request,
                 handler=_release_from_maintenance_handler,
             ),

--- a/src/isar/state_machine/states/maintenance.py
+++ b/src/isar/state_machine/states/maintenance.py
@@ -5,35 +5,33 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class Maintenance(State):
+def Maintenance(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        def _release_from_maintenance_handler(
-            _: EmptyMessage,
-        ) -> Transition[UnknownStatus.UnknownStatus]:
-            events.api_requests.release_from_maintenance_mode.response.trigger_event(
-                EmptyMessage()
-            )
-
-            return UnknownStatus.transition()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.release_from_maintenance_mode.request,
-                handler=_release_from_maintenance_handler,
-            ),
-        ]
-
-        super().__init__(
-            state_name=States.Maintenance,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def _release_from_maintenance_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        events.api_requests.release_from_maintenance_mode.response.trigger_event(
+            EmptyMessage()
         )
 
+        return UnknownStatus.transition()
 
-def transition_and_reply_to_API() -> Transition[Maintenance]:
-    def _transition(events: Events) -> Maintenance:
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.release_from_maintenance_mode.request,
+            handler=_release_from_maintenance_handler,
+        ),
+    ]
+
+    return State(
+        state_name=States.Maintenance,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
+
+
+def transition_and_reply_to_API() -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.set_maintenance_mode.response.trigger_event(
             MaintenanceResponse(is_maintenance_mode=True)
         )
@@ -42,8 +40,8 @@ def transition_and_reply_to_API() -> Transition[Maintenance]:
     return _transition
 
 
-def transition_without_replying_to_API() -> Transition[Maintenance]:
-    def _transition(events: Events) -> Maintenance:
+def transition_without_replying_to_API() -> Transition:
+    def _transition(events: Events) -> State:
         return Maintenance(events)
 
     return _transition

--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -14,97 +14,93 @@ from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.status import MissionStatus
 
 
-class Monitor(State):
+def Monitor(events: Events, mission_id: str) -> State:
 
-    def __init__(self, events: Events, mission_id: str):
-
-        def _mission_success_event_handler(
-            _: EmptyMessage,
-        ) -> Transition[AwaitNextMission.AwaitNextMission]:
-            publish_mission_status(
-                events.mqtt_queue, mission_id, MissionStatus.Successful, None
-            )
-            return AwaitNextMission.transition()
-
-        def _mission_failed_event_handler(
-            error_message: ErrorMessage,
-        ) -> Transition[AwaitNextMission.AwaitNextMission]:
-            publish_mission_status(
-                events.mqtt_queue,
-                mission_id,
-                MissionStatus.Failed,
-                error_message,
-            )
-            return AwaitNextMission.transition()
-
-        def _stop_mission_event_handler(
-            stop_mission_id: str,
-        ) -> Transition[Stopping.Stopping] | None:
-            if mission_id == stop_mission_id or stop_mission_id == "":
-                return Stopping.transition_and_trigger_stop_and_respond_to_API(
-                    mission_id
-                )
-            else:
-                events.api_requests.stop_mission.response.trigger_event(
-                    ControlMissionResponse(
-                        success=False, failure_reason="Mission not found"
-                    )
-                )
-                return None
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_started_successfully,
-                handler=lambda _: publish_mission_status(
-                    events.mqtt_queue, mission_id, MissionStatus.InProgress, None
-                ),
-            ),
-            EventHandlerMapping[str](
-                event=events.api_requests.stop_mission.request,
-                handler=_stop_mission_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.pause_mission.request,
-                handler=lambda _: Pausing.transition_and_pause_mission_and_reply_to_API(
-                    mission_id
-                ),
-            ),
-            EventHandlerMapping[ErrorMessage](
-                event=events.robot_service_events.mission_failed,
-                handler=_mission_failed_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_succeeded,
-                handler=_mission_success_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_below_mission_threshold,
-                handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: StoppingGoToLockdown.transition_and_stop_mission(
-                    mission_id
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(
-                    mission_id
-                ),
-            ),
-        ]
-        super().__init__(
-            state_name=States.Monitor,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def _mission_success_event_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        publish_mission_status(
+            events.mqtt_queue, mission_id, MissionStatus.Successful, None
         )
+        return AwaitNextMission.transition()
+
+    def _mission_failed_event_handler(
+        error_message: ErrorMessage,
+    ) -> Transition:
+        publish_mission_status(
+            events.mqtt_queue,
+            mission_id,
+            MissionStatus.Failed,
+            error_message,
+        )
+        return AwaitNextMission.transition()
+
+    def _stop_mission_event_handler(
+        stop_mission_id: str,
+    ) -> Transition | None:
+        if mission_id == stop_mission_id or stop_mission_id == "":
+            return Stopping.transition_and_trigger_stop_and_respond_to_API(mission_id)
+        else:
+            events.api_requests.stop_mission.response.trigger_event(
+                ControlMissionResponse(
+                    success=False, failure_reason="Mission not found"
+                )
+            )
+            return None
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_started_successfully,
+            handler=lambda _: publish_mission_status(
+                events.mqtt_queue, mission_id, MissionStatus.InProgress, None
+            ),
+        ),
+        EventHandlerMapping[str](
+            event=events.api_requests.stop_mission.request,
+            handler=_stop_mission_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.pause_mission.request,
+            handler=lambda _: Pausing.transition_and_pause_mission_and_reply_to_API(
+                mission_id
+            ),
+        ),
+        EventHandlerMapping[ErrorMessage](
+            event=events.robot_service_events.mission_failed,
+            handler=_mission_failed_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_succeeded,
+            handler=_mission_success_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_below_mission_threshold,
+            handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: StoppingGoToLockdown.transition_and_stop_mission(
+                mission_id
+            ),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(
+                mission_id
+            ),
+        ),
+    ]
+    return State(
+        state_name=States.Monitor,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_start_mission(
     mission: Mission, should_respond_to_API_request: bool = False
-) -> Transition[Monitor]:
-    def _transition(events: Events) -> Monitor:
+) -> Transition:
+    def _transition(events: Events) -> State:
         publish_mission_status(
             events.mqtt_queue, mission.id, MissionStatus.NotStarted, None
         )
@@ -123,8 +119,8 @@ def transition_and_start_mission(
     return _transition
 
 
-def transition_with_existing_mission(mission_id: str) -> Transition[Monitor]:
-    def _transition(events: Events) -> Monitor:
+def transition_with_existing_mission(mission_id: str) -> Transition:
+    def _transition(events: Events) -> State:
         return Monitor(events, mission_id=mission_id)
 
     return _transition

--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -59,46 +59,38 @@ class Monitor(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="mission_started_event",
                 event=events.robot_service_events.mission_started_successfully,
                 handler=_mission_started_event_handler,
             ),
             EventHandlerMapping[str](
-                name="stop_mission_event",
                 event=events.api_requests.stop_mission.request,
                 handler=_stop_mission_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="pause_mission_event",
                 event=events.api_requests.pause_mission.request,
                 handler=lambda _: Pausing.transition_and_pause_mission_and_reply_to_API(
                     mission_id
                 ),
             ),
             EventHandlerMapping[ErrorMessage](
-                name="mission_failed_event",
                 event=events.robot_service_events.mission_failed,
                 handler=_mission_failed_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_succeeded_event",
                 event=events.robot_service_events.mission_succeeded,
                 handler=_mission_success_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_below_threshold_event",
                 event=events.robot_service_events.battery_below_mission_threshold,
                 handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: StoppingGoToLockdown.transition_and_stop_mission(
                     mission_id
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(
                     mission_id

--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -19,7 +19,7 @@ class Monitor(State):
     def __init__(self, events: Events, mission_id: str):
 
         def _mission_success_event_handler(
-            success: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[AwaitNextMission.AwaitNextMission]:
             publish_mission_status(
                 events.mqtt_queue, mission_id, MissionStatus.Successful, None
@@ -52,15 +52,12 @@ class Monitor(State):
                 )
                 return None
 
-        def _mission_started_event_handler(mission_started: EmptyMessage) -> None:
-            publish_mission_status(
-                events.mqtt_queue, mission_id, MissionStatus.InProgress, None
-            )
-
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
                 event=events.robot_service_events.mission_started_successfully,
-                handler=_mission_started_event_handler,
+                handler=lambda _: publish_mission_status(
+                    events.mqtt_queue, mission_id, MissionStatus.InProgress, None
+                ),
             ),
             EventHandlerMapping[str](
                 event=events.api_requests.stop_mission.request,

--- a/src/isar/state_machine/states/offline.py
+++ b/src/isar/state_machine/states/offline.py
@@ -47,12 +47,10 @@ class Offline(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[RobotStatus](
-                name="robot_status_event",
                 event=events.robot_service_events.robot_status_update,
                 handler=_robot_status_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: Maintenance.transition_and_reply_to_API(),
             ),

--- a/src/isar/state_machine/states/offline.py
+++ b/src/isar/state_machine/states/offline.py
@@ -8,50 +8,42 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import RobotStatus
 
 
-class Offline(State):
+def Offline(events: Events) -> State:
 
-    def __init__(self, events: Events):
+    def _robot_status_event_handler(
+        robot_status: RobotStatus,
+    ) -> Transition | None:
+        if robot_status == RobotStatus.Offline:
+            return None
+        elif robot_status == RobotStatus.Home:
+            return Home.transition()
+        elif robot_status == RobotStatus.Available:
+            return InterventionNeeded.transition(
+                "Robot not home after going online. Localisation likely needed"
+            )
+        elif robot_status == RobotStatus.TeleOperation:
+            return Maintenance.transition_without_replying_to_API()
+        return UnknownStatus.transition()
 
-        def _robot_status_event_handler(
-            robot_status: RobotStatus,
-        ) -> (
-            Transition[Home.Home]
-            | Transition[InterventionNeeded.InterventionNeeded]
-            | Transition[Maintenance.Maintenance]
-            | Transition[UnknownStatus.UnknownStatus]
-            | None
-        ):
-            if robot_status == RobotStatus.Offline:
-                return None
-            elif robot_status == RobotStatus.Home:
-                return Home.transition()
-            elif robot_status == RobotStatus.Available:
-                return InterventionNeeded.transition(
-                    "Robot not home after going online. Localisation likely needed"
-                )
-            elif robot_status == RobotStatus.TeleOperation:
-                return Maintenance.transition_without_replying_to_API()
-            return UnknownStatus.transition()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[RobotStatus](
-                event=events.robot_service_events.robot_status_update,
-                handler=_robot_status_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: Maintenance.transition_and_reply_to_API(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.Offline,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[RobotStatus](
+            event=events.robot_service_events.robot_status_update,
+            handler=_robot_status_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: Maintenance.transition_and_reply_to_API(),
+        ),
+    ]
+    return State(
+        state_name=States.Offline,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition() -> Transition[Offline]:
-    def _transition(events: Events) -> Offline:
+def transition() -> Transition:
+    def _transition(events: Events) -> State:
         return Offline(events)
 
     return _transition

--- a/src/isar/state_machine/states/offline.py
+++ b/src/isar/state_machine/states/offline.py
@@ -24,25 +24,13 @@ class Offline(State):
             if robot_status == RobotStatus.Offline:
                 return None
             elif robot_status == RobotStatus.Home:
-                self.logger.info(
-                    "Got robot status home while in offline state. Leaving offline state."
-                )
                 return Home.transition()
             elif robot_status == RobotStatus.Available:
-                self.logger.info(
-                    "Got robot status available while in offline state. Leaving offline state."
-                )
                 return InterventionNeeded.transition(
                     "Robot not home after going online. Localisation likely needed"
                 )
             elif robot_status == RobotStatus.TeleOperation:
-                self.logger.info(
-                    "Got robot status teleoperation while in offline state. Leaving offline state."
-                )
                 return Maintenance.transition_without_replying_to_API()
-            self.logger.info(
-                f"Got unexpected status {robot_status} while in offline state. Leaving offline state."
-            )
             return UnknownStatus.transition()
 
         event_handlers: list[EventHandlerMapping] = [

--- a/src/isar/state_machine/states/paused.py
+++ b/src/isar/state_machine/states/paused.py
@@ -9,62 +9,58 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class Paused(State):
+def Paused(events: Events, mission_id: str) -> State:
 
-    def __init__(self, events: Events, mission_id: str):
-
-        def _stop_mission_event_handler(
-            stop_mission_id: str,
-        ) -> Transition[StoppingPausedMission.StoppingPausedMission] | None:
-            if mission_id == stop_mission_id or stop_mission_id == "":
-                return StoppingPausedMission.transition_and_trigger_stop(
-                    mission_id, True
+    def _stop_mission_event_handler(
+        stop_mission_id: str,
+    ) -> Transition | None:
+        if mission_id == stop_mission_id or stop_mission_id == "":
+            return StoppingPausedMission.transition_and_trigger_stop(mission_id, True)
+        else:
+            events.api_requests.stop_mission.response.trigger_event(
+                ControlMissionResponse(
+                    success=False, failure_reason="Mission not found"
                 )
-            else:
-                events.api_requests.stop_mission.response.trigger_event(
-                    ControlMissionResponse(
-                        success=False, failure_reason="Mission not found"
-                    )
-                )
-                return None
+            )
+            return None
 
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[str](
-                event=events.api_requests.stop_mission.request,
-                handler=_stop_mission_event_handler,
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[str](
+            event=events.api_requests.stop_mission.request,
+            handler=_stop_mission_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.resume_mission.request,
+            handler=lambda _: Resuming.transition_resume_mission_and_respond_to_API(
+                mission_id
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.resume_mission.request,
-                handler=lambda _: Resuming.transition_resume_mission_and_respond_to_API(
-                    mission_id
-                ),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_below_mission_threshold,
+            handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: StoppingGoToLockdown.transition_and_stop_mission(
+                mission_id
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_below_mission_threshold,
-                handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(
+                mission_id
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: StoppingGoToLockdown.transition_and_stop_mission(
-                    mission_id
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(
-                    mission_id
-                ),
-            ),
-        ]
-        super().__init__(
-            state_name=States.Paused,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+    ]
+    return State(
+        state_name=States.Paused,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition(mission_id: str) -> Transition[Paused]:
-    def _transition(events: Events) -> Paused:
+def transition(mission_id: str) -> Transition:
+    def _transition(events: Events) -> State:
         return Paused(events, mission_id)
 
     return _transition

--- a/src/isar/state_machine/states/paused.py
+++ b/src/isar/state_machine/states/paused.py
@@ -30,31 +30,26 @@ class Paused(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[str](
-                name="stop_mission_event",
                 event=events.api_requests.stop_mission.request,
                 handler=_stop_mission_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="resume_mission_event",
                 event=events.api_requests.resume_mission.request,
                 handler=lambda _: Resuming.transition_resume_mission_and_respond_to_API(
                     mission_id
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_below_threshold_event",
                 event=events.robot_service_events.battery_below_mission_threshold,
                 handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: StoppingGoToLockdown.transition_and_stop_mission(
                     mission_id
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(
                     mission_id

--- a/src/isar/state_machine/states/pausing.py
+++ b/src/isar/state_machine/states/pausing.py
@@ -13,7 +13,7 @@ class Pausing(State):
     def __init__(self, events: Events, mission_id: str):
 
         def _successful_pause_event_handler(
-            successful_pause: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[Paused.Paused]:
             publish_mission_status(
                 events.mqtt_queue, mission_id, MissionStatus.Paused, None

--- a/src/isar/state_machine/states/pausing.py
+++ b/src/isar/state_machine/states/pausing.py
@@ -8,39 +8,37 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import MissionStatus
 
 
-class Pausing(State):
+def Pausing(events: Events, mission_id: str) -> State:
 
-    def __init__(self, events: Events, mission_id: str):
-
-        def _successful_pause_event_handler(
-            _: EmptyMessage,
-        ) -> Transition[Paused.Paused]:
-            publish_mission_status(
-                events.mqtt_queue, mission_id, MissionStatus.Paused, None
-            )
-            return Paused.transition(mission_id)
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_pause,
-                handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_successfully_paused,
-                handler=_successful_pause_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.Pausing,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def _successful_pause_event_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        publish_mission_status(
+            events.mqtt_queue, mission_id, MissionStatus.Paused, None
         )
+        return Paused.transition(mission_id)
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_pause,
+            handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_successfully_paused,
+            handler=_successful_pause_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.Pausing,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_pause_mission_and_reply_to_API(
     mission_id: str,
-) -> Transition[Pausing]:
-    def _transition(events: Events) -> Pausing:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.pause_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )

--- a/src/isar/state_machine/states/pausing.py
+++ b/src/isar/state_machine/states/pausing.py
@@ -22,12 +22,10 @@ class Pausing(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_pause_event",
                 event=events.robot_service_events.mission_failed_to_pause,
                 handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="successful_pause_event",
                 event=events.robot_service_events.mission_successfully_paused,
                 handler=_successful_pause_event_handler,
             ),

--- a/src/isar/state_machine/states/pausing_return_home.py
+++ b/src/isar/state_machine/states/pausing_return_home.py
@@ -6,29 +6,27 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class PausingReturnHome(State):
+def PausingReturnHome(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_pause,
-                handler=lambda _: ReturningHome.transition_to_existing_mission(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_successfully_paused,
-                handler=lambda _: ReturnHomePaused.transition(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.PausingReturnHome,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_pause,
+            handler=lambda _: ReturningHome.transition_to_existing_mission(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_successfully_paused,
+            handler=lambda _: ReturnHomePaused.transition(),
+        ),
+    ]
+    return State(
+        state_name=States.PausingReturnHome,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition_and_pause_mission_and_reply_to_API() -> Transition[PausingReturnHome]:
-    def _transition(events: Events) -> PausingReturnHome:
+def transition_and_pause_mission_and_reply_to_API() -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.pause_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )

--- a/src/isar/state_machine/states/pausing_return_home.py
+++ b/src/isar/state_machine/states/pausing_return_home.py
@@ -12,12 +12,10 @@ class PausingReturnHome(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_pause_event",
                 event=events.robot_service_events.mission_failed_to_pause,
                 handler=lambda _: ReturningHome.transition_to_existing_mission(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="successful_pause_event",
                 event=events.robot_service_events.mission_successfully_paused,
                 handler=lambda _: ReturnHomePaused.transition(),
             ),

--- a/src/isar/state_machine/states/recharging.py
+++ b/src/isar/state_machine/states/recharging.py
@@ -12,16 +12,6 @@ class Recharging(State):
 
     def __init__(self, events: Events):
 
-        def robot_offline_handler(
-            robot_status: RobotStatus,
-        ) -> Transition[Offline.Offline] | None:
-            if robot_status == RobotStatus.Offline:
-                self.logger.info(
-                    "Got robot status offline while in recharging state. Leaving recharging state."
-                )
-                return Offline.transition()
-            return None
-
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
                 event=events.robot_service_events.battery_above_recharge_threshold_event,
@@ -29,7 +19,11 @@ class Recharging(State):
             ),
             EventHandlerMapping[RobotStatus](
                 event=events.robot_service_events.robot_status_update,
-                handler=robot_offline_handler,
+                handler=lambda robot_status: (
+                    Offline.transition()
+                    if robot_status == RobotStatus.Offline
+                    else None
+                ),
             ),
             EventHandlerMapping[EmptyMessage](
                 event=events.api_requests.send_to_lockdown.request,

--- a/src/isar/state_machine/states/recharging.py
+++ b/src/isar/state_machine/states/recharging.py
@@ -24,22 +24,18 @@ class Recharging(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_above_recharge_threshold_event",
                 event=events.robot_service_events.battery_above_recharge_threshold_event,
                 handler=lambda _: Home.transition(),
             ),
             EventHandlerMapping[RobotStatus](
-                name="robot_offline_event",
                 event=events.robot_service_events.robot_status_update,
                 handler=robot_offline_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: Lockdown.transition_and_respond_to_api(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: Maintenance.transition_and_reply_to_API(),
             ),

--- a/src/isar/state_machine/states/recharging.py
+++ b/src/isar/state_machine/states/recharging.py
@@ -8,41 +8,37 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import RobotStatus
 
 
-class Recharging(State):
+def Recharging(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_above_recharge_threshold,
-                handler=lambda _: Home.transition(),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_above_recharge_threshold,
+            handler=lambda _: Home.transition(),
+        ),
+        EventHandlerMapping[RobotStatus](
+            event=events.robot_service_events.robot_status_update,
+            handler=lambda robot_status: (
+                Offline.transition() if robot_status == RobotStatus.Offline else None
             ),
-            EventHandlerMapping[RobotStatus](
-                event=events.robot_service_events.robot_status_update,
-                handler=lambda robot_status: (
-                    Offline.transition()
-                    if robot_status == RobotStatus.Offline
-                    else None
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: Lockdown.transition_and_respond_to_api(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: Maintenance.transition_and_reply_to_API(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.Recharging,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: Lockdown.transition_and_respond_to_api(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: Maintenance.transition_and_reply_to_API(),
+        ),
+    ]
+    return State(
+        state_name=States.Recharging,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition() -> Transition[Recharging]:
-    def _transition(events: Events) -> Recharging:
+def transition() -> Transition:
+    def _transition(events: Events) -> State:
         return Recharging(events)
 
     return _transition

--- a/src/isar/state_machine/states/recharging.py
+++ b/src/isar/state_machine/states/recharging.py
@@ -14,7 +14,7 @@ class Recharging(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_above_recharge_threshold_event,
+                event=events.robot_service_events.battery_above_recharge_threshold,
                 handler=lambda _: Home.transition(),
             ),
             EventHandlerMapping[RobotStatus](

--- a/src/isar/state_machine/states/recharging_with_mission.py
+++ b/src/isar/state_machine/states/recharging_with_mission.py
@@ -32,7 +32,7 @@ class RechargingWithMission(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_above_recharge_threshold_event,
+                event=events.robot_service_events.battery_above_recharge_threshold,
                 handler=lambda _: Monitor.transition_and_start_mission(
                     mission, should_respond_to_API_request=False
                 ),

--- a/src/isar/state_machine/states/recharging_with_mission.py
+++ b/src/isar/state_machine/states/recharging_with_mission.py
@@ -42,29 +42,24 @@ class RechargingWithMission(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_above_recharging_threshold_event",
                 event=events.robot_service_events.battery_above_recharge_threshold_event,
                 handler=lambda _: Monitor.transition_and_start_mission(
                     mission, should_respond_to_API_request=False
                 ),
             ),
             EventHandlerMapping[RobotStatus](
-                name="robot_offline_event",
                 event=events.robot_service_events.robot_status_update,
                 handler=robot_offline_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: Lockdown.transition_and_respond_to_api(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: Maintenance.transition_and_reply_to_API(),
             ),
             EventHandlerMapping[str](
-                name="stop_mission_event",
                 event=events.api_requests.stop_mission.request,
                 handler=_stop_mission_event_handler,
             ),

--- a/src/isar/state_machine/states/recharging_with_mission.py
+++ b/src/isar/state_machine/states/recharging_with_mission.py
@@ -10,63 +10,59 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import RobotStatus
 
 
-class RechargingWithMission(State):
+def RechargingWithMission(events: Events, mission: AbortedMission) -> State:
 
-    def __init__(self, events: Events, mission: AbortedMission):
-
-        def _stop_mission_event_handler(
-            stop_mission_id: str,
-        ) -> Transition[Recharging.Recharging] | None:
-            if mission.id == stop_mission_id or stop_mission_id == "":
-                events.api_requests.stop_mission.response.trigger_event(
-                    ControlMissionResponse(success=True)
+    def _stop_mission_event_handler(
+        stop_mission_id: str,
+    ) -> Transition | None:
+        if mission.id == stop_mission_id or stop_mission_id == "":
+            events.api_requests.stop_mission.response.trigger_event(
+                ControlMissionResponse(success=True)
+            )
+            return Recharging.transition()
+        else:
+            events.api_requests.stop_mission.response.trigger_event(
+                ControlMissionResponse(
+                    success=False, failure_reason="Mission not found"
                 )
-                return Recharging.transition()
-            else:
-                events.api_requests.stop_mission.response.trigger_event(
-                    ControlMissionResponse(
-                        success=False, failure_reason="Mission not found"
-                    )
-                )
-                return None
+            )
+            return None
 
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_above_recharge_threshold,
-                handler=lambda _: Monitor.transition_and_start_mission(
-                    mission, should_respond_to_API_request=False
-                ),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_above_recharge_threshold,
+            handler=lambda _: Monitor.transition_and_start_mission(
+                mission, should_respond_to_API_request=False
             ),
-            EventHandlerMapping[RobotStatus](
-                event=events.robot_service_events.robot_status_update,
-                handler=lambda robot_status: (
-                    Offline.transition()
-                    if robot_status == RobotStatus.Offline
-                    else None
-                ),
+        ),
+        EventHandlerMapping[RobotStatus](
+            event=events.robot_service_events.robot_status_update,
+            handler=lambda robot_status: (
+                Offline.transition() if robot_status == RobotStatus.Offline else None
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: Lockdown.transition_and_respond_to_api(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: Maintenance.transition_and_reply_to_API(),
-            ),
-            EventHandlerMapping[str](
-                event=events.api_requests.stop_mission.request,
-                handler=_stop_mission_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.RechargingWithMission,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: Lockdown.transition_and_respond_to_api(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: Maintenance.transition_and_reply_to_API(),
+        ),
+        EventHandlerMapping[str](
+            event=events.api_requests.stop_mission.request,
+            handler=_stop_mission_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.RechargingWithMission,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition(mission: AbortedMission) -> Transition[RechargingWithMission]:
-    def _transition(events: Events) -> RechargingWithMission:
+def transition(mission: AbortedMission) -> Transition:
+    def _transition(events: Events) -> State:
         return RechargingWithMission(events, mission=mission)
 
     return _transition

--- a/src/isar/state_machine/states/recharging_with_mission.py
+++ b/src/isar/state_machine/states/recharging_with_mission.py
@@ -14,16 +14,6 @@ class RechargingWithMission(State):
 
     def __init__(self, events: Events, mission: AbortedMission):
 
-        def robot_offline_handler(
-            robot_status: RobotStatus,
-        ) -> Transition[Offline.Offline] | None:
-            if robot_status == RobotStatus.Offline:
-                self.logger.info(
-                    "Got robot status offline while in recharging state. Leaving recharging state."
-                )
-                return Offline.transition()
-            return None
-
         def _stop_mission_event_handler(
             stop_mission_id: str,
         ) -> Transition[Recharging.Recharging] | None:
@@ -49,7 +39,11 @@ class RechargingWithMission(State):
             ),
             EventHandlerMapping[RobotStatus](
                 event=events.robot_service_events.robot_status_update,
-                handler=robot_offline_handler,
+                handler=lambda robot_status: (
+                    Offline.transition()
+                    if robot_status == RobotStatus.Offline
+                    else None
+                ),
             ),
             EventHandlerMapping[EmptyMessage](
                 event=events.api_requests.send_to_lockdown.request,

--- a/src/isar/state_machine/states/resuming.py
+++ b/src/isar/state_machine/states/resuming.py
@@ -8,39 +8,37 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import MissionStatus
 
 
-class Resuming(State):
+def Resuming(events: Events, mission_id: str) -> State:
 
-    def __init__(self, events: Events, mission_id: str):
-
-        def _successful_resume_event_handler(
-            _: EmptyMessage,
-        ) -> Transition[Monitor.Monitor]:
-            publish_mission_status(
-                events.mqtt_queue, mission_id, MissionStatus.InProgress, None
-            )
-            return Monitor.transition_with_existing_mission(mission_id)
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_resume,
-                handler=lambda _: Paused.transition(mission_id),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_successfully_resumed,
-                handler=_successful_resume_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.Resuming,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def _successful_resume_event_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        publish_mission_status(
+            events.mqtt_queue, mission_id, MissionStatus.InProgress, None
         )
+        return Monitor.transition_with_existing_mission(mission_id)
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_resume,
+            handler=lambda _: Paused.transition(mission_id),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_successfully_resumed,
+            handler=_successful_resume_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.Resuming,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_resume_mission_and_respond_to_API(
     mission_id: str,
-) -> Transition[Resuming]:
-    def _transition(events: Events) -> Resuming:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.resume_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )

--- a/src/isar/state_machine/states/resuming.py
+++ b/src/isar/state_machine/states/resuming.py
@@ -13,7 +13,7 @@ class Resuming(State):
     def __init__(self, events: Events, mission_id: str):
 
         def _successful_resume_event_handler(
-            successful_resume: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[Monitor.Monitor]:
             publish_mission_status(
                 events.mqtt_queue, mission_id, MissionStatus.InProgress, None

--- a/src/isar/state_machine/states/resuming.py
+++ b/src/isar/state_machine/states/resuming.py
@@ -22,12 +22,10 @@ class Resuming(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_resume_event",
                 event=events.robot_service_events.mission_failed_to_resume,
                 handler=lambda _: Paused.transition(mission_id),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="successful_resume_event",
                 event=events.robot_service_events.mission_successfully_resumed,
                 handler=_successful_resume_event_handler,
             ),

--- a/src/isar/state_machine/states/resuming_return_home.py
+++ b/src/isar/state_machine/states/resuming_return_home.py
@@ -12,12 +12,10 @@ class ResumingReturnHome(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_resume_event",
                 event=events.robot_service_events.mission_failed_to_resume,
                 handler=lambda _: ReturnHomePaused.transition(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="successful_resume_event",
                 event=events.robot_service_events.mission_successfully_resumed,
                 handler=lambda _: ReturningHome.transition_to_existing_mission(),
             ),

--- a/src/isar/state_machine/states/resuming_return_home.py
+++ b/src/isar/state_machine/states/resuming_return_home.py
@@ -6,29 +6,27 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class ResumingReturnHome(State):
+def ResumingReturnHome(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_resume,
-                handler=lambda _: ReturnHomePaused.transition(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_successfully_resumed,
-                handler=lambda _: ReturningHome.transition_to_existing_mission(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.ResumingReturnHome,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_resume,
+            handler=lambda _: ReturnHomePaused.transition(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_successfully_resumed,
+            handler=lambda _: ReturningHome.transition_to_existing_mission(),
+        ),
+    ]
+    return State(
+        state_name=States.ResumingReturnHome,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition_and_resume_mission_and_reply_to_API() -> Transition[ResumingReturnHome]:
-    def _transition(events: Events) -> ResumingReturnHome:
+def transition_and_resume_mission_and_reply_to_API() -> Transition:
+    def _transition(events: Events) -> State:
         events.api_requests.resume_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )

--- a/src/isar/state_machine/states/return_home_paused.py
+++ b/src/isar/state_machine/states/return_home_paused.py
@@ -9,50 +9,48 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 
 
-class ReturnHomePaused(State):
+def ReturnHomePaused(events: Events) -> State:
 
-    def __init__(self, events: Events):
+    def _send_to_lockdown_event_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        events.state_machine_events.resume_mission.trigger_event(EmptyMessage())
 
-        def _send_to_lockdown_event_handler(
-            _: EmptyMessage,
-        ) -> Transition[GoingToLockdown.GoingToLockdown]:
-            events.state_machine_events.resume_mission.trigger_event(EmptyMessage())
+        return GoingToLockdown.transition_to_existing_mission_and_report_to_api()
 
-            return GoingToLockdown.transition_to_existing_mission_and_report_to_api()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.resume_mission.request,
-                handler=lambda _: ResumingReturnHome.transition_and_resume_mission_and_reply_to_API(),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.resume_mission.request,
+            handler=lambda _: ResumingReturnHome.transition_and_resume_mission_and_reply_to_API(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_below_mission_threshold,
+            handler=lambda _: ReturningHome.transition_to_existing_mission(),
+        ),
+        EventHandlerMapping[Mission](
+            event=events.api_requests.start_mission.request,
+            handler=lambda mission: StoppingPausedReturnHome.transition_and_stop_return_home_and_reply_to_API(
+                mission
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_below_mission_threshold,
-                handler=lambda _: ReturningHome.transition_to_existing_mission(),
-            ),
-            EventHandlerMapping[Mission](
-                event=events.api_requests.start_mission.request,
-                handler=lambda mission: StoppingPausedReturnHome.transition_and_stop_return_home_and_reply_to_API(
-                    mission
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=_send_to_lockdown_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.ReturnHomePaused,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=_send_to_lockdown_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(),
+        ),
+    ]
+    return State(
+        state_name=States.ReturnHomePaused,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition() -> Transition[ReturnHomePaused]:
-    def _transition(events: Events) -> ReturnHomePaused:
+def transition() -> Transition:
+    def _transition(events: Events) -> State:
         return ReturnHomePaused(events)
 
     return _transition

--- a/src/isar/state_machine/states/return_home_paused.py
+++ b/src/isar/state_machine/states/return_home_paused.py
@@ -14,7 +14,7 @@ class ReturnHomePaused(State):
     def __init__(self, events: Events):
 
         def _send_to_lockdown_event_handler(
-            should_lockdown: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[GoingToLockdown.GoingToLockdown]:
             events.state_machine_events.resume_mission.trigger_event(EmptyMessage())
 

--- a/src/isar/state_machine/states/return_home_paused.py
+++ b/src/isar/state_machine/states/return_home_paused.py
@@ -22,29 +22,24 @@ class ReturnHomePaused(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="resume_return_home_event",
                 event=events.api_requests.resume_mission.request,
                 handler=lambda _: ResumingReturnHome.transition_and_resume_mission_and_reply_to_API(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_below_threshold_event",
                 event=events.robot_service_events.battery_below_mission_threshold,
                 handler=lambda _: ReturningHome.transition_to_existing_mission(),
             ),
             EventHandlerMapping[Mission](
-                name="start_mission_event",
                 event=events.api_requests.start_mission.request,
                 handler=lambda mission: StoppingPausedReturnHome.transition_and_stop_return_home_and_reply_to_API(
                     mission
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=_send_to_lockdown_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(),
             ),

--- a/src/isar/state_machine/states/returning_home.py
+++ b/src/isar/state_machine/states/returning_home.py
@@ -22,7 +22,7 @@ class ReturningHome(State):
     ):
 
         def _mission_failed_event_handler(
-            error_message: ErrorMessage,
+            _: ErrorMessage,
         ) -> (
             Transition[InterventionNeeded.InterventionNeeded]
             | Transition[ReturningHome]

--- a/src/isar/state_machine/states/returning_home.py
+++ b/src/isar/state_machine/states/returning_home.py
@@ -13,71 +13,65 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage
 from robot_interface.models.mission.mission import Mission, ReturnHomeMission
 
 
-class ReturningHome(State):
+def ReturningHome(
+    events: Events,
+    retries: int = settings.RETURN_HOME_RETRY_LIMIT - 1,
+) -> State:
 
-    def __init__(
-        self,
-        events: Events,
-        retries: int = settings.RETURN_HOME_RETRY_LIMIT - 1,
-    ):
+    def _mission_failed_event_handler(
+        _: ErrorMessage,
+    ) -> Transition:
+        if retries < 1:
+            return InterventionNeeded.transition(
+                f"Return home failed after {settings.RETURN_HOME_RETRY_LIMIT} attempts"
+            )
+        else:
+            return transition_and_start_mission(False, retries - 1)
 
-        def _mission_failed_event_handler(
-            _: ErrorMessage,
-        ) -> (
-            Transition[InterventionNeeded.InterventionNeeded]
-            | Transition[ReturningHome]
-        ):
-            if retries < 1:
-                return InterventionNeeded.transition(
-                    f"Return home failed after {settings.RETURN_HOME_RETRY_LIMIT} attempts"
-                )
-            else:
-                return transition_and_start_mission(False, retries - 1)
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.pause_mission.request,
-                handler=lambda _: PausingReturnHome.transition_and_pause_mission_and_reply_to_API(),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.pause_mission.request,
+            handler=lambda _: PausingReturnHome.transition_and_pause_mission_and_reply_to_API(),
+        ),
+        EventHandlerMapping[ErrorMessage](
+            event=events.robot_service_events.mission_failed,
+            handler=_mission_failed_event_handler,
+        ),
+        EventHandlerMapping[Mission](
+            event=events.api_requests.start_mission.request,
+            handler=lambda mission: StoppingReturnHome.transition_and_stop_return_home_and_reply_to_API(
+                mission
             ),
-            EventHandlerMapping[ErrorMessage](
-                event=events.robot_service_events.mission_failed,
-                handler=_mission_failed_event_handler,
-            ),
-            EventHandlerMapping[Mission](
-                event=events.api_requests.start_mission.request,
-                handler=lambda mission: StoppingReturnHome.transition_and_stop_return_home_and_reply_to_API(
-                    mission
-                ),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_succeeded,
-                handler=lambda _: Home.transition(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.battery_below_mission_threshold,
-                handler=lambda _: GoingToRecharging.transition_to_existing_mission(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.send_to_lockdown.request,
-                handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.ReturningHome,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_succeeded,
+            handler=lambda _: Home.transition(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.battery_below_mission_threshold,
+            handler=lambda _: GoingToRecharging.transition_to_existing_mission(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.send_to_lockdown.request,
+            handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(),
+        ),
+    ]
+    return State(
+        state_name=States.ReturningHome,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_start_mission(
     should_respond_to_API_request: bool = False,
     retries: int = settings.RETURN_HOME_RETRY_LIMIT - 1,
-) -> Transition[ReturningHome]:
-    def _transition(events: Events) -> ReturningHome:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.robot_service_events.mission_failed.clear_event()
         events.robot_service_events.mission_succeeded.clear_event()
 
@@ -90,8 +84,8 @@ def transition_and_start_mission(
     return _transition
 
 
-def transition_to_existing_mission() -> Transition[ReturningHome]:
-    def _transition(events: Events) -> ReturningHome:
+def transition_to_existing_mission() -> Transition:
+    def _transition(events: Events) -> State:
         return ReturningHome(events)
 
     return _transition

--- a/src/isar/state_machine/states/returning_home.py
+++ b/src/isar/state_machine/states/returning_home.py
@@ -36,39 +36,32 @@ class ReturningHome(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="pause_mission_event",
                 event=events.api_requests.pause_mission.request,
                 handler=lambda _: PausingReturnHome.transition_and_pause_mission_and_reply_to_API(),
             ),
             EventHandlerMapping[ErrorMessage](
-                name="mission_failed_event",
                 event=events.robot_service_events.mission_failed,
                 handler=_mission_failed_event_handler,
             ),
             EventHandlerMapping[Mission](
-                name="start_mission_event",
                 event=events.api_requests.start_mission.request,
                 handler=lambda mission: StoppingReturnHome.transition_and_stop_return_home_and_reply_to_API(
                     mission
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_succeeded_event",
                 event=events.robot_service_events.mission_succeeded,
                 handler=lambda _: Home.transition(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="robot_battery_below_threshold_event",
                 event=events.robot_service_events.battery_below_mission_threshold,
                 handler=lambda _: GoingToRecharging.transition_to_existing_mission(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="send_to_lockdown_event",
                 event=events.api_requests.send_to_lockdown.request,
                 handler=lambda _: GoingToLockdown.transition_to_existing_mission_and_report_to_api(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: StoppingDueToMaintenance.transition_and_stop_mission(),
             ),

--- a/src/isar/state_machine/states/stopping.py
+++ b/src/isar/state_machine/states/stopping.py
@@ -28,17 +28,14 @@ class Stopping(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=_successful_stop_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=_successful_stop_event_handler,
             ),

--- a/src/isar/state_machine/states/stopping.py
+++ b/src/isar/state_machine/states/stopping.py
@@ -9,48 +9,44 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, Err
 from robot_interface.models.mission.status import MissionStatus
 
 
-class Stopping(State):
+def Stopping(events: Events, mission_id: str) -> State:
 
-    def __init__(self, events: Events, mission_id: str):
-
-        def _successful_stop_event_handler(
-            _: AbortedMission | EmptyMessage,
-        ) -> Transition[AwaitNextMission.AwaitNextMission]:
-            publish_mission_status(
-                events.mqtt_queue,
-                mission_id,
-                MissionStatus.Cancelled,
-                ErrorMessage(
-                    ErrorReason.RobotActionException, "Mission stopped by user"
-                ),
-            )
-            return AwaitNextMission.transition()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
-            ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=_successful_stop_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=_successful_stop_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.Stopping,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def _successful_stop_event_handler(
+        _: AbortedMission | EmptyMessage,
+    ) -> Transition:
+        publish_mission_status(
+            events.mqtt_queue,
+            mission_id,
+            MissionStatus.Cancelled,
+            ErrorMessage(ErrorReason.RobotActionException, "Mission stopped by user"),
         )
+        return AwaitNextMission.transition()
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=_successful_stop_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=_successful_stop_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.Stopping,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_trigger_stop_and_respond_to_API(
     mission_id: str,
-) -> Transition[Stopping]:
-    def _transition(events: Events) -> Stopping:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
         events.api_requests.stop_mission.response.trigger_event(
             ControlMissionResponse(success=True)

--- a/src/isar/state_machine/states/stopping.py
+++ b/src/isar/state_machine/states/stopping.py
@@ -14,7 +14,7 @@ class Stopping(State):
     def __init__(self, events: Events, mission_id: str):
 
         def _successful_stop_event_handler(
-            successful_stop: AbortedMission | EmptyMessage,
+            _: AbortedMission | EmptyMessage,
         ) -> Transition[AwaitNextMission.AwaitNextMission]:
             publish_mission_status(
                 events.mqtt_queue,

--- a/src/isar/state_machine/states/stopping_due_to_maintenance.py
+++ b/src/isar/state_machine/states/stopping_due_to_maintenance.py
@@ -7,59 +7,57 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class StoppingDueToMaintenance(State):
+def StoppingDueToMaintenance(events: Events, mission_id: str | None = None) -> State:
 
-    def __init__(self, events: Events, mission_id: str | None = None):
-
-        def _failed_stop_event_handler(
-            _: EmptyMessage,
-        ) -> Transition[InterventionNeeded.InterventionNeeded]:
-            events.api_requests.set_maintenance_mode.response.trigger_event(
-                MaintenanceResponse(
-                    is_maintenance_mode=False,
-                    failure_reason="Failed to stop ongoing mission",
-                )
+    def _failed_stop_event_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        events.api_requests.set_maintenance_mode.response.trigger_event(
+            MaintenanceResponse(
+                is_maintenance_mode=False,
+                failure_reason="Failed to stop ongoing mission",
             )
-            return InterventionNeeded.transition(
-                "Failed to stop mission when entering maintenance mode"
-            )
-
-        def _successful_stop_event_handler(
-            _: AbortedMission | EmptyMessage,
-        ) -> Transition[Maintenance.Maintenance]:
-            if mission_id:
-                publish_mission_aborted(
-                    events.mqtt_queue,
-                    mission_id,
-                    "Mission aborted, robot being sent to maintenance",
-                )
-            return Maintenance.transition_and_reply_to_API()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=_failed_stop_event_handler,
-            ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=_successful_stop_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=_successful_stop_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.StoppingDueToMaintenance,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
         )
+        return InterventionNeeded.transition(
+            "Failed to stop mission when entering maintenance mode"
+        )
+
+    def _successful_stop_event_handler(
+        _: AbortedMission | EmptyMessage,
+    ) -> Transition:
+        if mission_id:
+            publish_mission_aborted(
+                events.mqtt_queue,
+                mission_id,
+                "Mission aborted, robot being sent to maintenance",
+            )
+        return Maintenance.transition_and_reply_to_API()
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=_failed_stop_event_handler,
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=_successful_stop_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=_successful_stop_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.StoppingDueToMaintenance,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_stop_mission(
     mission_id: str | None = None,
-) -> Transition[StoppingDueToMaintenance]:
-    def _transition(events: Events) -> StoppingDueToMaintenance:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
         return StoppingDueToMaintenance(events, mission_id)
 

--- a/src/isar/state_machine/states/stopping_due_to_maintenance.py
+++ b/src/isar/state_machine/states/stopping_due_to_maintenance.py
@@ -12,7 +12,7 @@ class StoppingDueToMaintenance(State):
     def __init__(self, events: Events, mission_id: str | None = None):
 
         def _failed_stop_event_handler(
-            empty_event: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[InterventionNeeded.InterventionNeeded]:
             events.api_requests.set_maintenance_mode.response.trigger_event(
                 MaintenanceResponse(
@@ -25,7 +25,7 @@ class StoppingDueToMaintenance(State):
             )
 
         def _successful_stop_event_handler(
-            successful_stop: AbortedMission | EmptyMessage,
+            _: AbortedMission | EmptyMessage,
         ) -> Transition[Maintenance.Maintenance]:
             if mission_id:
                 publish_mission_aborted(

--- a/src/isar/state_machine/states/stopping_due_to_maintenance.py
+++ b/src/isar/state_machine/states/stopping_due_to_maintenance.py
@@ -37,17 +37,14 @@ class StoppingDueToMaintenance(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=_failed_stop_event_handler,
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=_successful_stop_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=_successful_stop_event_handler,
             ),

--- a/src/isar/state_machine/states/stopping_go_to_lockdown.py
+++ b/src/isar/state_machine/states/stopping_go_to_lockdown.py
@@ -12,7 +12,7 @@ class StoppingGoToLockdown(State):
     def __init__(self, events: Events, mission_id: str):
 
         def _failed_stop_event_handler(
-            empty_event: EmptyMessage,
+            _: EmptyMessage,
         ) -> Transition[Monitor.Monitor]:
             events.api_requests.send_to_lockdown.response.trigger_event(
                 LockdownResponse(
@@ -23,7 +23,7 @@ class StoppingGoToLockdown(State):
             return Monitor.transition_with_existing_mission(mission_id)
 
         def _successful_stop_event_handler(
-            successful_stop: AbortedMission | EmptyMessage,
+            _: AbortedMission | EmptyMessage,
         ) -> Transition[GoingToLockdown.GoingToLockdown]:
             publish_mission_aborted(
                 events.mqtt_queue, mission_id, "Robot being sent to lockdown"

--- a/src/isar/state_machine/states/stopping_go_to_lockdown.py
+++ b/src/isar/state_machine/states/stopping_go_to_lockdown.py
@@ -7,52 +7,50 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class StoppingGoToLockdown(State):
+def StoppingGoToLockdown(events: Events, mission_id: str) -> State:
 
-    def __init__(self, events: Events, mission_id: str):
-
-        def _failed_stop_event_handler(
-            _: EmptyMessage,
-        ) -> Transition[Monitor.Monitor]:
-            events.api_requests.send_to_lockdown.response.trigger_event(
-                LockdownResponse(
-                    lockdown_started=False,
-                    failure_reason="Failed to stop ongoing mission",
-                )
+    def _failed_stop_event_handler(
+        _: EmptyMessage,
+    ) -> Transition:
+        events.api_requests.send_to_lockdown.response.trigger_event(
+            LockdownResponse(
+                lockdown_started=False,
+                failure_reason="Failed to stop ongoing mission",
             )
-            return Monitor.transition_with_existing_mission(mission_id)
-
-        def _successful_stop_event_handler(
-            _: AbortedMission | EmptyMessage,
-        ) -> Transition[GoingToLockdown.GoingToLockdown]:
-            publish_mission_aborted(
-                events.mqtt_queue, mission_id, "Robot being sent to lockdown"
-            )
-            return GoingToLockdown.transition_and_start_mission_and_report_to_api()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=_failed_stop_event_handler,
-            ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=_successful_stop_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=_successful_stop_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.StoppingGoToLockdown,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
         )
+        return Monitor.transition_with_existing_mission(mission_id)
+
+    def _successful_stop_event_handler(
+        _: AbortedMission | EmptyMessage,
+    ) -> Transition:
+        publish_mission_aborted(
+            events.mqtt_queue, mission_id, "Robot being sent to lockdown"
+        )
+        return GoingToLockdown.transition_and_start_mission_and_report_to_api()
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=_failed_stop_event_handler,
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=_successful_stop_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=_successful_stop_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.StoppingGoToLockdown,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition_and_stop_mission(mission_id: str) -> Transition[StoppingGoToLockdown]:
-    def _transition(events: Events) -> StoppingGoToLockdown:
+def transition_and_stop_mission(mission_id: str) -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
         return StoppingGoToLockdown(events, mission_id)
 

--- a/src/isar/state_machine/states/stopping_go_to_lockdown.py
+++ b/src/isar/state_machine/states/stopping_go_to_lockdown.py
@@ -32,17 +32,14 @@ class StoppingGoToLockdown(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=_failed_stop_event_handler,
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=_successful_stop_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=_successful_stop_event_handler,
             ),

--- a/src/isar/state_machine/states/stopping_go_to_recharge.py
+++ b/src/isar/state_machine/states/stopping_go_to_recharge.py
@@ -6,37 +6,35 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class StoppingGoToRecharge(State):
+def StoppingGoToRecharge(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=lambda _: InterventionNeeded.transition(
-                    "Failed to stop mission when battery was low"
-                ),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=lambda _: InterventionNeeded.transition(
+                "Failed to stop mission when battery was low"
             ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=lambda aborted_mission: GoingToRechargingWithMission.transition_and_start_return_home(
-                    aborted_mission
-                ),
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=lambda aborted_mission: GoingToRechargingWithMission.transition_and_start_return_home(
+                aborted_mission
             ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.StoppingGoToRecharge,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
+        ),
+    ]
+    return State(
+        state_name=States.StoppingGoToRecharge,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition_and_stop_mission() -> Transition[StoppingGoToRecharge]:
-    def _transition(events: Events) -> StoppingGoToRecharge:
+def transition_and_stop_mission() -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
         return StoppingGoToRecharge(events)
 

--- a/src/isar/state_machine/states/stopping_go_to_recharge.py
+++ b/src/isar/state_machine/states/stopping_go_to_recharge.py
@@ -12,21 +12,18 @@ class StoppingGoToRecharge(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=lambda _: InterventionNeeded.transition(
                     "Failed to stop mission when battery was low"
                 ),
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=lambda aborted_mission: GoingToRechargingWithMission.transition_and_start_return_home(
                     aborted_mission
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
             ),

--- a/src/isar/state_machine/states/stopping_paused_mission.py
+++ b/src/isar/state_machine/states/stopping_paused_mission.py
@@ -8,43 +8,41 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import MissionStatus
 
 
-class StoppingPausedMission(State):
+def StoppingPausedMission(events: Events, mission_id: str) -> State:
 
-    def __init__(self, events: Events, mission_id: str):
-
-        def _successful_stop_event_handler(
-            _: AbortedMission | EmptyMessage,
-        ) -> Transition[AwaitNextMission.AwaitNextMission]:
-            publish_mission_status(
-                events.mqtt_queue, mission_id, MissionStatus.Cancelled, None
-            )
-            return AwaitNextMission.transition()
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=lambda _: Paused.transition(mission_id),
-            ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=_successful_stop_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=_successful_stop_event_handler,
-            ),
-        ]
-        super().__init__(
-            state_name=States.StoppingPausedMission,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
+    def _successful_stop_event_handler(
+        _: AbortedMission | EmptyMessage,
+    ) -> Transition:
+        publish_mission_status(
+            events.mqtt_queue, mission_id, MissionStatus.Cancelled, None
         )
+        return AwaitNextMission.transition()
+
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=lambda _: Paused.transition(mission_id),
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=_successful_stop_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=_successful_stop_event_handler,
+        ),
+    ]
+    return State(
+        state_name=States.StoppingPausedMission,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_trigger_stop(
     mission_id: str, should_respond_to_API_request: bool = False
-) -> Transition[StoppingPausedMission]:
-    def _transition(events: Events) -> StoppingPausedMission:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
         if should_respond_to_API_request:
             events.api_requests.stop_mission.response.trigger_event(

--- a/src/isar/state_machine/states/stopping_paused_mission.py
+++ b/src/isar/state_machine/states/stopping_paused_mission.py
@@ -22,17 +22,14 @@ class StoppingPausedMission(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=lambda _: Paused.transition(mission_id),
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=_successful_stop_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=_successful_stop_event_handler,
             ),

--- a/src/isar/state_machine/states/stopping_paused_mission.py
+++ b/src/isar/state_machine/states/stopping_paused_mission.py
@@ -13,7 +13,7 @@ class StoppingPausedMission(State):
     def __init__(self, events: Events, mission_id: str):
 
         def _successful_stop_event_handler(
-            successful_stop: AbortedMission | EmptyMessage,
+            _: AbortedMission | EmptyMessage,
         ) -> Transition[AwaitNextMission.AwaitNextMission]:
             publish_mission_status(
                 events.mqtt_queue, mission_id, MissionStatus.Cancelled, None

--- a/src/isar/state_machine/states/stopping_paused_return_home.py
+++ b/src/isar/state_machine/states/stopping_paused_return_home.py
@@ -7,35 +7,33 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 
 
-class StoppingPausedReturnHome(State):
+def StoppingPausedReturnHome(events: Events, mission: Mission) -> State:
 
-    def __init__(self, events: Events, mission: Mission):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=lambda _: ReturnHomePaused.transition(),
-            ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=lambda _: Monitor.transition_and_start_mission(mission, True),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=lambda _: Monitor.transition_and_start_mission(mission, True),
-            ),
-        ]
-        super().__init__(
-            state_name=States.StoppingPausedReturnHome,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=lambda _: ReturnHomePaused.transition(),
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=lambda _: Monitor.transition_and_start_mission(mission, True),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=lambda _: Monitor.transition_and_start_mission(mission, True),
+        ),
+    ]
+    return State(
+        state_name=States.StoppingPausedReturnHome,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_stop_return_home_and_reply_to_API(
     mission: Mission,
-) -> Transition[StoppingPausedReturnHome]:
-    def _transition(events: Events) -> StoppingPausedReturnHome:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
 
         response = MissionStartResponse(

--- a/src/isar/state_machine/states/stopping_paused_return_home.py
+++ b/src/isar/state_machine/states/stopping_paused_return_home.py
@@ -13,17 +13,14 @@ class StoppingPausedReturnHome(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=lambda _: ReturnHomePaused.transition(),
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=lambda _: Monitor.transition_and_start_mission(mission, True),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=lambda _: Monitor.transition_and_start_mission(mission, True),
             ),

--- a/src/isar/state_machine/states/stopping_return_home.py
+++ b/src/isar/state_machine/states/stopping_return_home.py
@@ -7,35 +7,33 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 
 
-class StoppingReturnHome(State):
+def StoppingReturnHome(events: Events, mission: Mission) -> State:
 
-    def __init__(self, events: Events, mission: Mission):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=lambda _: ReturningHome.transition_to_existing_mission(),
-            ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=lambda _: Monitor.transition_and_start_mission(mission, True),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=lambda _: Monitor.transition_and_start_mission(mission, True),
-            ),
-        ]
-        super().__init__(
-            state_name=States.StoppingReturnHome,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=lambda _: ReturningHome.transition_to_existing_mission(),
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=lambda _: Monitor.transition_and_start_mission(mission, True),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=lambda _: Monitor.transition_and_start_mission(mission, True),
+        ),
+    ]
+    return State(
+        state_name=States.StoppingReturnHome,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
 def transition_and_stop_return_home_and_reply_to_API(
     mission: Mission,
-) -> Transition[StoppingReturnHome]:
-    def _transition(events: Events) -> StoppingReturnHome:
+) -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
         response = MissionStartResponse(
             mission_id=mission.id,

--- a/src/isar/state_machine/states/stopping_return_home.py
+++ b/src/isar/state_machine/states/stopping_return_home.py
@@ -18,15 +18,11 @@ class StoppingReturnHome(State):
             ),
             EventHandlerMapping[AbortedMission](
                 event=events.robot_service_events.mission_successfully_stopped,
-                handler=lambda event: Monitor.transition_and_start_mission(
-                    mission, True
-                ),
+                handler=lambda _: Monitor.transition_and_start_mission(mission, True),
             ),
             EventHandlerMapping[EmptyMessage](
                 event=events.robot_service_events.stopped_mission_already_done,
-                handler=lambda event: Monitor.transition_and_start_mission(
-                    mission, True
-                ),
+                handler=lambda _: Monitor.transition_and_start_mission(mission, True),
             ),
         ]
         super().__init__(

--- a/src/isar/state_machine/states/stopping_return_home.py
+++ b/src/isar/state_machine/states/stopping_return_home.py
@@ -13,19 +13,16 @@ class StoppingReturnHome(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=lambda _: ReturningHome.transition_to_existing_mission(),
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=lambda event: Monitor.transition_and_start_mission(
                     mission, True
                 ),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=lambda event: Monitor.transition_and_start_mission(
                     mission, True

--- a/src/isar/state_machine/states/stopping_unknown_mission.py
+++ b/src/isar/state_machine/states/stopping_unknown_mission.py
@@ -5,35 +5,33 @@ from isar.state_machine.state import EventHandlerMapping, State, Transition
 from isar.state_machine.states_enum import States
 
 
-class StoppingUnknownMission(State):
+def StoppingUnknownMission(events: Events) -> State:
 
-    def __init__(self, events: Events):
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.mission_failed_to_stop,
-                handler=lambda _: InterventionNeeded.transition(
-                    "Failed to stop unknown mission"
-                ),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.mission_failed_to_stop,
+            handler=lambda _: InterventionNeeded.transition(
+                "Failed to stop unknown mission"
             ),
-            EventHandlerMapping[AbortedMission](
-                event=events.robot_service_events.mission_successfully_stopped,
-                handler=lambda _: AwaitNextMission.transition(),
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.robot_service_events.stopped_mission_already_done,
-                handler=lambda _: AwaitNextMission.transition(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.StoppingUnknownMission,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[AbortedMission](
+            event=events.robot_service_events.mission_successfully_stopped,
+            handler=lambda _: AwaitNextMission.transition(),
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.robot_service_events.stopped_mission_already_done,
+            handler=lambda _: AwaitNextMission.transition(),
+        ),
+    ]
+    return State(
+        state_name=States.StoppingUnknownMission,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition() -> Transition[StoppingUnknownMission]:
-    def _transition(events: Events) -> StoppingUnknownMission:
+def transition() -> Transition:
+    def _transition(events: Events) -> State:
         events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
         return StoppingUnknownMission(events)
 

--- a/src/isar/state_machine/states/stopping_unknown_mission.py
+++ b/src/isar/state_machine/states/stopping_unknown_mission.py
@@ -11,19 +11,16 @@ class StoppingUnknownMission(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[EmptyMessage](
-                name="failed_stop_event",
                 event=events.robot_service_events.mission_failed_to_stop,
                 handler=lambda _: InterventionNeeded.transition(
                     "Failed to stop unknown mission"
                 ),
             ),
             EventHandlerMapping[AbortedMission](
-                name="successful_stop_event",
                 event=events.robot_service_events.mission_successfully_stopped,
                 handler=lambda _: AwaitNextMission.transition(),
             ),
             EventHandlerMapping[EmptyMessage](
-                name="mission_already_done_event",
                 event=events.robot_service_events.stopped_mission_already_done,
                 handler=lambda _: AwaitNextMission.transition(),
             ),

--- a/src/isar/state_machine/states/unknown_status.py
+++ b/src/isar/state_machine/states/unknown_status.py
@@ -53,19 +53,16 @@ class UnknownStatus(State):
 
         event_handlers: list[EventHandlerMapping] = [
             EventHandlerMapping[str](
-                name="stop_mission_event",
                 event=events.api_requests.stop_mission.request,
                 handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
                     mission_id
                 ),
             ),
             EventHandlerMapping[RobotStatus](
-                name="robot_status_event",
                 event=events.robot_service_events.robot_status_update,
                 handler=_robot_status_event_handler,
             ),
             EventHandlerMapping[EmptyMessage](
-                name="set_maintenance_mode",
                 event=events.api_requests.set_maintenance_mode.request,
                 handler=lambda _: Maintenance.transition_and_reply_to_API(),
             ),

--- a/src/isar/state_machine/states/unknown_status.py
+++ b/src/isar/state_machine/states/unknown_status.py
@@ -10,57 +10,48 @@ from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import RobotStatus
 
 
-class UnknownStatus(State):
+def UnknownStatus(events: Events) -> State:
 
-    def __init__(self, events: Events):
+    def _robot_status_event_handler(
+        robot_status: RobotStatus,
+    ) -> Transition | None:
+        if robot_status == RobotStatus.Home:
+            return Home.transition()
+        elif robot_status == RobotStatus.Available:
+            return AwaitNextMission.transition()
+        elif robot_status == RobotStatus.Offline:
+            return Offline.transition()
+        elif robot_status == RobotStatus.TeleOperation:
+            return Maintenance.transition_without_replying_to_API()
+        elif robot_status == RobotStatus.Busy:
+            return StoppingUnknownMission.transition()
+        return None
 
-        def _robot_status_event_handler(
-            robot_status: RobotStatus,
-        ) -> (
-            Transition[Home.Home]
-            | Transition[AwaitNextMission.AwaitNextMission]
-            | Transition[Offline.Offline]
-            | Transition[Maintenance.Maintenance]
-            | Transition[StoppingUnknownMission.StoppingUnknownMission]
-            | None
-        ):
-            if robot_status == RobotStatus.Home:
-                return Home.transition()
-            elif robot_status == RobotStatus.Available:
-                return AwaitNextMission.transition()
-            elif robot_status == RobotStatus.Offline:
-                return Offline.transition()
-            elif robot_status == RobotStatus.TeleOperation:
-                return Maintenance.transition_without_replying_to_API()
-            elif robot_status == RobotStatus.Busy:
-                return StoppingUnknownMission.transition()
-            return None
-
-        event_handlers: list[EventHandlerMapping] = [
-            EventHandlerMapping[str](
-                event=events.api_requests.stop_mission.request,
-                handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
-                    mission_id
-                ),
+    event_handlers: list[EventHandlerMapping] = [
+        EventHandlerMapping[str](
+            event=events.api_requests.stop_mission.request,
+            handler=lambda mission_id: Stopping.transition_and_trigger_stop_and_respond_to_API(
+                mission_id
             ),
-            EventHandlerMapping[RobotStatus](
-                event=events.robot_service_events.robot_status_update,
-                handler=_robot_status_event_handler,
-            ),
-            EventHandlerMapping[EmptyMessage](
-                event=events.api_requests.set_maintenance_mode.request,
-                handler=lambda _: Maintenance.transition_and_reply_to_API(),
-            ),
-        ]
-        super().__init__(
-            state_name=States.UnknownStatus,
-            signal_exit_event=events.signal_state_machine_exit,
-            event_handler_mappings=event_handlers,
-        )
+        ),
+        EventHandlerMapping[RobotStatus](
+            event=events.robot_service_events.robot_status_update,
+            handler=_robot_status_event_handler,
+        ),
+        EventHandlerMapping[EmptyMessage](
+            event=events.api_requests.set_maintenance_mode.request,
+            handler=lambda _: Maintenance.transition_and_reply_to_API(),
+        ),
+    ]
+    return State(
+        state_name=States.UnknownStatus,
+        signal_exit_event=events.signal_state_machine_exit,
+        event_handler_mappings=event_handlers,
+    )
 
 
-def transition() -> Transition[UnknownStatus]:
-    def _transition(events: Events) -> UnknownStatus:
+def transition() -> Transition:
+    def _transition(events: Events) -> State:
         return UnknownStatus(events)
 
     return _transition

--- a/src/isar/state_machine/states/unknown_status.py
+++ b/src/isar/state_machine/states/unknown_status.py
@@ -25,29 +25,14 @@ class UnknownStatus(State):
             | None
         ):
             if robot_status == RobotStatus.Home:
-                self.logger.info(
-                    "Got robot status home while in unknown status state. Leaving unknown status state."
-                )
                 return Home.transition()
             elif robot_status == RobotStatus.Available:
-                self.logger.info(
-                    "Got robot status available while in unknown status state. Leaving unknown status state."
-                )
                 return AwaitNextMission.transition()
             elif robot_status == RobotStatus.Offline:
-                self.logger.info(
-                    "Got robot status offline while in unknown status state. Leaving unknown status state."
-                )
                 return Offline.transition()
             elif robot_status == RobotStatus.TeleOperation:
-                self.logger.info(
-                    "Got robot status teleoperation while in unknown status state. Leaving unknown status state."
-                )
                 return Maintenance.transition_without_replying_to_API()
             elif robot_status == RobotStatus.Busy:
-                self.logger.info(
-                    "Got robot status busy while in unknown status state. Leaving unknown status state."
-                )
                 return StoppingUnknownMission.transition()
             return None
 

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -82,11 +82,9 @@ def test_state_machine_with_successful_mission_stop(
 def test_transition_from_resuming_to_paused(events: Events) -> None:
     current_state = Resuming(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_resume_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(
@@ -103,10 +101,9 @@ def test_unknown_status_transitions_to_await_next_mission_if_it_was_already_avai
 ) -> None:
     current_state = UnknownStatus(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_status_event"
     )
-    assert event_handler is not None
 
     transition = event_handler.handler(RobotStatus.Available)
 
@@ -119,11 +116,9 @@ def test_transition_from_resuming_return_home_to_await_next_mission(
 ) -> None:
     current_state = ResumingReturnHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_resume_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -7,11 +7,8 @@ from isar.models.events import Events
 from isar.modules import ApplicationContainer
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.await_next_mission import AwaitNextMission
-from isar.state_machine.states.paused import Paused
 from isar.state_machine.states.resuming import Resuming
 from isar.state_machine.states.resuming_return_home import ResumingReturnHome
-from isar.state_machine.states.return_home_paused import ReturnHomePaused
 from isar.state_machine.states.unknown_status import UnknownStatus
 from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
@@ -93,7 +90,7 @@ def test_transition_from_resuming_to_paused(events: Events) -> None:
     )
 
     current_state = transition(events)
-    assert type(current_state) is Paused
+    assert current_state.name is States.Paused
 
 
 def test_unknown_status_transitions_to_await_next_mission_if_it_was_already_available(
@@ -108,7 +105,7 @@ def test_unknown_status_transitions_to_await_next_mission_if_it_was_already_avai
     transition = event_handler.handler(RobotStatus.Available)
 
     current_state = transition(events)
-    assert type(current_state) is AwaitNextMission
+    assert current_state.name is States.AwaitNextMission
 
 
 def test_transition_from_resuming_return_home_to_await_next_mission(
@@ -127,4 +124,4 @@ def test_transition_from_resuming_return_home_to_await_next_mission(
     )
 
     current_state = transition(events)
-    assert type(current_state) is ReturnHomePaused
+    assert current_state.name is States.ReturnHomePaused

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -82,8 +82,8 @@ def test_state_machine_with_successful_mission_stop(
 def test_transition_from_resuming_to_paused(events: Events) -> None:
     current_state = Resuming(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_resume_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_resume
     )
 
     transition = event_handler.handler(
@@ -101,8 +101,8 @@ def test_unknown_status_transitions_to_await_next_mission_if_it_was_already_avai
 ) -> None:
     current_state = UnknownStatus(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_status_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Available)
@@ -116,8 +116,8 @@ def test_transition_from_resuming_return_home_to_await_next_mission(
 ) -> None:
     current_state = ResumingReturnHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_resume_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_resume
     )
 
     transition = event_handler.handler(

--- a/tests/isar/state_machine/states/test_going_to_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_going_to_lockdown_state.py
@@ -16,8 +16,8 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
 ) -> None:
     current_state: State = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "send_to_lockdown_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.send_to_lockdown.request
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -28,7 +28,9 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
     assert type(current_state) is GoingToLockdown
 
     lockdown_event_handler: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("mission_failed_to_resume")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.mission_failed_to_resume
+        )
     )
 
     transition = lockdown_event_handler.handler(
@@ -45,8 +47,8 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
 def test_stopping_lockdown_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = StoppingGoToLockdown(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_stopped
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -66,8 +68,8 @@ def test_stopping_lockdown_transitions_to_going_to_lockdown(events: Events) -> N
 def test_return_home_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = ReturningHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "send_to_lockdown_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.send_to_lockdown.request
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -79,8 +81,8 @@ def test_return_home_transitions_to_going_to_lockdown(events: Events) -> None:
 def test_recharging_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = GoingToRecharging(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "send_to_lockdown_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.send_to_lockdown.request
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -92,8 +94,8 @@ def test_recharging_transitions_to_going_to_lockdown(events: Events) -> None:
 def test_await_next_mission_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = AwaitNextMission(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "send_to_lockdown_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.send_to_lockdown.request
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_going_to_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_going_to_lockdown_state.py
@@ -16,7 +16,7 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
 ) -> None:
     current_state: State = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "send_to_lockdown_event"
     )
 
@@ -27,10 +27,9 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
     assert events.api_requests.send_to_lockdown.response.has_event()
     assert type(current_state) is GoingToLockdown
 
-    lockdown_event_handler: EventHandlerMapping | None = (
+    lockdown_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_name("mission_failed_to_resume")
     )
-    assert lockdown_event_handler is not None
 
     transition = lockdown_event_handler.handler(
         ErrorMessage(
@@ -46,11 +45,9 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
 def test_stopping_lockdown_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = StoppingGoToLockdown(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -69,11 +66,9 @@ def test_stopping_lockdown_transitions_to_going_to_lockdown(events: Events) -> N
 def test_return_home_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = ReturningHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "send_to_lockdown_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -84,11 +79,9 @@ def test_return_home_transitions_to_going_to_lockdown(events: Events) -> None:
 def test_recharging_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = GoingToRecharging(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "send_to_lockdown_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -99,11 +92,9 @@ def test_recharging_transitions_to_going_to_lockdown(events: Events) -> None:
 def test_await_next_mission_transitions_to_going_to_lockdown(events: Events) -> None:
     current_state = AwaitNextMission(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "send_to_lockdown_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_going_to_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_going_to_lockdown_state.py
@@ -2,12 +2,11 @@ from isar.config.settings import settings
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping, State
 from isar.state_machine.states.await_next_mission import AwaitNextMission
-from isar.state_machine.states.going_to_lockdown import GoingToLockdown
 from isar.state_machine.states.going_to_recharging import GoingToRecharging
-from isar.state_machine.states.intervention_needed import InterventionNeeded
 from isar.state_machine.states.return_home_paused import ReturnHomePaused
 from isar.state_machine.states.returning_home import ReturningHome
 from isar.state_machine.states.stopping_go_to_lockdown import StoppingGoToLockdown
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 
 
@@ -25,7 +24,7 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
     current_state = transition(events)
 
     assert events.api_requests.send_to_lockdown.response.has_event()
-    assert type(current_state) is GoingToLockdown
+    assert current_state.name is States.GoingToLockdown
 
     lockdown_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
@@ -41,7 +40,7 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
     )
 
     current_state = transition(events)
-    assert type(current_state) is InterventionNeeded
+    assert current_state.name is States.InterventionNeeded
 
 
 def test_stopping_lockdown_transitions_to_going_to_lockdown(events: Events) -> None:
@@ -54,7 +53,7 @@ def test_stopping_lockdown_transitions_to_going_to_lockdown(events: Events) -> N
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is GoingToLockdown
+    assert current_state.name is States.GoingToLockdown
 
     assert events.api_requests.send_to_lockdown.response.check().lockdown_started
 
@@ -75,7 +74,7 @@ def test_return_home_transitions_to_going_to_lockdown(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is GoingToLockdown
+    assert current_state.name is States.GoingToLockdown
 
 
 def test_recharging_transitions_to_going_to_lockdown(events: Events) -> None:
@@ -88,7 +87,7 @@ def test_recharging_transitions_to_going_to_lockdown(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is GoingToLockdown
+    assert current_state.name is States.GoingToLockdown
 
 
 def test_await_next_mission_transitions_to_going_to_lockdown(events: Events) -> None:
@@ -101,6 +100,6 @@ def test_await_next_mission_transitions_to_going_to_lockdown(events: Events) -> 
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is GoingToLockdown
+    assert current_state.name is States.GoingToLockdown
 
     assert events.api_requests.send_to_lockdown.response.check()

--- a/tests/isar/state_machine/states/test_going_to_recharging_state.py
+++ b/tests/isar/state_machine/states/test_going_to_recharging_state.py
@@ -12,8 +12,8 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_when_no_remaining_task
     events: Events,
 ) -> None:
     current_state = StoppingGoToRecharge(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "mission_already_done_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.stopped_mission_already_done
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -26,8 +26,8 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
     events: Events,
 ) -> None:
     current_state = StoppingGoToRecharge(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_stopped
     )
 
     transition = event_handler.handler(AbortedMission(id="id", name="test"))
@@ -40,8 +40,8 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
 
 def test_return_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = ReturningHome(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_battery_below_threshold_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -54,8 +54,8 @@ def test_cancelling_mission_when_going_home_to_recharge(events: Events) -> None:
     current_state = GoingToRechargingWithMission(
         events, mission=AbortedMission(name="test", id="test_id")
     )
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "stop_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.stop_mission.request
     )
 
     transition = event_handler.handler("test_id")

--- a/tests/isar/state_machine/states/test_going_to_recharging_state.py
+++ b/tests/isar/state_machine/states/test_going_to_recharging_state.py
@@ -12,11 +12,9 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_when_no_remaining_task
     events: Events,
 ) -> None:
     current_state = StoppingGoToRecharge(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "mission_already_done_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -28,11 +26,9 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
     events: Events,
 ) -> None:
     current_state = StoppingGoToRecharge(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(AbortedMission(id="id", name="test"))
 
@@ -44,11 +40,9 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
 
 def test_return_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = ReturningHome(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_battery_below_threshold_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -60,11 +54,9 @@ def test_cancelling_mission_when_going_home_to_recharge(events: Events) -> None:
     current_state = GoingToRechargingWithMission(
         events, mission=AbortedMission(name="test", id="test_id")
     )
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "stop_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler("test_id")
 

--- a/tests/isar/state_machine/states/test_going_to_recharging_state.py
+++ b/tests/isar/state_machine/states/test_going_to_recharging_state.py
@@ -1,11 +1,11 @@
 from isar.models.events import AbortedMission, EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.going_to_recharging import GoingToRecharging
 from isar.state_machine.states.going_to_recharging_with_mission import (
     GoingToRechargingWithMission,
 )
 from isar.state_machine.states.returning_home import ReturningHome
 from isar.state_machine.states.stopping_go_to_recharge import StoppingGoToRecharge
+from isar.state_machine.states_enum import States
 
 
 def test_stopping_to_recharge_goes_to_going_to_recharging_when_no_remaining_tasks(
@@ -19,7 +19,7 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_when_no_remaining_task
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is GoingToRecharging
+    assert current_state.name is States.GoingToRecharging
 
 
 def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
@@ -35,7 +35,7 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
     assert events.mqtt_queue.empty()
 
     current_state = transition(events)
-    assert type(current_state) is GoingToRechargingWithMission
+    assert current_state.name is States.GoingToRechargingWithMission
 
 
 def test_return_home_goes_to_recharging_when_battery_low(events: Events) -> None:
@@ -47,7 +47,7 @@ def test_return_home_goes_to_recharging_when_battery_low(events: Events) -> None
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is GoingToRecharging
+    assert current_state.name is States.GoingToRecharging
 
 
 def test_cancelling_mission_when_going_home_to_recharge(events: Events) -> None:
@@ -61,4 +61,4 @@ def test_cancelling_mission_when_going_home_to_recharge(events: Events) -> None:
     transition = event_handler.handler("test_id")
 
     current_state = transition(events)
-    assert type(current_state) is GoingToRecharging
+    assert current_state.name is States.GoingToRecharging

--- a/tests/isar/state_machine/states/test_home_state.py
+++ b/tests/isar/state_machine/states/test_home_state.py
@@ -12,8 +12,8 @@ from robot_interface.models.mission.status import RobotStatus
 def test_lockdown_transitions_to_home(events: Events) -> None:
     current_state = Lockdown(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "release_from_lockdown"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.release_from_lockdown.request
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -29,10 +29,14 @@ def test_state_machine_with_return_home_failure_successful_retries(
     current_state = ReturningHome(events)
 
     event_handler_success: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("mission_succeeded_event")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.mission_succeeded
+        )
     )
     event_handler_failure: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("mission_failed_event")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.mission_failed
+        )
     )
 
     transition = event_handler_failure.handler(
@@ -56,8 +60,8 @@ def test_intervention_needed_transitions_to_home_if_robot_is_home(
 ) -> None:
     current_state = InterventionNeeded(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_status_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Home)
@@ -71,8 +75,8 @@ def test_intervention_needed_transitions_to_home_if_robot_is_home(
 def test_recharging_goes_to_home_when_battery_high(events: Events) -> None:
     current_state = Recharging(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_battery_above_recharge_threshold_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.battery_above_recharge_threshold_event
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_home_state.py
+++ b/tests/isar/state_machine/states/test_home_state.py
@@ -12,11 +12,9 @@ from robot_interface.models.mission.status import RobotStatus
 def test_lockdown_transitions_to_home(events: Events) -> None:
     current_state = Lockdown(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "release_from_lockdown"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -30,15 +28,12 @@ def test_state_machine_with_return_home_failure_successful_retries(
 ) -> None:
     current_state = ReturningHome(events)
 
-    event_handler_success: EventHandlerMapping | None = (
+    event_handler_success: EventHandlerMapping = (
         current_state.get_event_handler_by_name("mission_succeeded_event")
     )
-    event_handler_failure: EventHandlerMapping | None = (
+    event_handler_failure: EventHandlerMapping = (
         current_state.get_event_handler_by_name("mission_failed_event")
     )
-
-    assert event_handler_success is not None
-    assert event_handler_failure is not None
 
     transition = event_handler_failure.handler(
         ErrorMessage(
@@ -61,10 +56,9 @@ def test_intervention_needed_transitions_to_home_if_robot_is_home(
 ) -> None:
     current_state = InterventionNeeded(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_status_event"
     )
-    assert event_handler is not None
 
     transition = event_handler.handler(RobotStatus.Home)
 
@@ -77,11 +71,9 @@ def test_intervention_needed_transitions_to_home_if_robot_is_home(
 def test_recharging_goes_to_home_when_battery_high(events: Events) -> None:
     current_state = Recharging(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_battery_above_recharge_threshold_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_home_state.py
+++ b/tests/isar/state_machine/states/test_home_state.py
@@ -1,10 +1,10 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.home import Home
 from isar.state_machine.states.intervention_needed import InterventionNeeded
 from isar.state_machine.states.lockdown import Lockdown
 from isar.state_machine.states.recharging import Recharging
 from isar.state_machine.states.returning_home import ReturningHome
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 from robot_interface.models.mission.status import RobotStatus
 
@@ -20,7 +20,7 @@ def test_lockdown_transitions_to_home(events: Events) -> None:
 
     assert events.api_requests.release_from_lockdown.response.check()
     current_state = transition(events)
-    assert type(current_state) is Home
+    assert current_state.name is States.Home
 
 
 def test_state_machine_with_return_home_failure_successful_retries(
@@ -47,12 +47,12 @@ def test_state_machine_with_return_home_failure_successful_retries(
     )
 
     assert transition is not None  # type: ignore
-    assert type(current_state) is ReturningHome
+    assert current_state.name is States.ReturningHome
 
     transition = event_handler_success.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Home
+    assert current_state.name is States.Home
 
 
 def test_intervention_needed_transitions_to_home_if_robot_is_home(
@@ -69,7 +69,7 @@ def test_intervention_needed_transitions_to_home_if_robot_is_home(
     assert transition is not None
 
     current_state = transition(events)
-    assert type(current_state) is Home
+    assert current_state.name is States.Home
 
 
 def test_recharging_goes_to_home_when_battery_high(events: Events) -> None:
@@ -83,4 +83,4 @@ def test_recharging_goes_to_home_when_battery_high(events: Events) -> None:
 
     current_state = transition(events)
 
-    assert type(current_state) is Home
+    assert current_state.name is States.Home

--- a/tests/isar/state_machine/states/test_home_state.py
+++ b/tests/isar/state_machine/states/test_home_state.py
@@ -76,7 +76,7 @@ def test_recharging_goes_to_home_when_battery_high(events: Events) -> None:
     current_state = Recharging(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_above_recharge_threshold_event
+        events.robot_service_events.battery_above_recharge_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_intervention_needed_state.py
+++ b/tests/isar/state_machine/states/test_intervention_needed_state.py
@@ -11,11 +11,9 @@ from robot_interface.models.mission.status import RobotStatus
 
 def test_going_to_recharging_goes_to_intervention_needed(events: Events) -> None:
     current_state = GoingToRecharging(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "mission_failed_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(
@@ -33,11 +31,9 @@ def test_going_to_lockdown_task_failed_transitions_to_intervention_needed(
 ) -> None:
     current_state = GoingToLockdown(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "mission_failed_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(
@@ -55,11 +51,9 @@ def test_going_to_lockdown_mission_failed_transitions_to_intervention_needed(
 ) -> None:
     current_state = GoingToLockdown(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "mission_failed_event"
     )
-
-    assert event_handler is not None
 
     # The type of error reason is not important for this test
     transition = event_handler.handler(
@@ -73,7 +67,7 @@ def test_going_to_lockdown_mission_failed_transitions_to_intervention_needed(
 def test_state_machine_with_return_home_failure(events: Events) -> None:
     current_state = ReturningHome(events)
 
-    failure_event_handler: EventHandlerMapping | None
+    failure_event_handler: EventHandlerMapping
 
     for i in range(settings.RETURN_HOME_RETRY_LIMIT - 1):
 
@@ -112,10 +106,9 @@ def test_intervention_needed_transitions_does_not_transition_if_status_is_not_ho
 ) -> None:
     current_state = InterventionNeeded(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_status_event"
     )
-    assert event_handler is not None
 
     statuses = [
         RobotStatus.Available,

--- a/tests/isar/state_machine/states/test_intervention_needed_state.py
+++ b/tests/isar/state_machine/states/test_intervention_needed_state.py
@@ -11,8 +11,8 @@ from robot_interface.models.mission.status import RobotStatus
 
 def test_going_to_recharging_goes_to_intervention_needed(events: Events) -> None:
     current_state = GoingToRecharging(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "mission_failed_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed
     )
 
     transition = event_handler.handler(
@@ -31,8 +31,8 @@ def test_going_to_lockdown_task_failed_transitions_to_intervention_needed(
 ) -> None:
     current_state = GoingToLockdown(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "mission_failed_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed
     )
 
     transition = event_handler.handler(
@@ -51,8 +51,8 @@ def test_going_to_lockdown_mission_failed_transitions_to_intervention_needed(
 ) -> None:
     current_state = GoingToLockdown(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "mission_failed_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed
     )
 
     # The type of error reason is not important for this test
@@ -71,8 +71,8 @@ def test_state_machine_with_return_home_failure(events: Events) -> None:
 
     for i in range(settings.RETURN_HOME_RETRY_LIMIT - 1):
 
-        failure_event_handler = current_state.get_event_handler_by_name(
-            "mission_failed_event"
+        failure_event_handler = current_state.get_event_handler_by_event(
+            events.robot_service_events.mission_failed
         )
 
         transition = failure_event_handler.handler(
@@ -86,8 +86,8 @@ def test_state_machine_with_return_home_failure(events: Events) -> None:
         current_state = transition(events)
         assert type(current_state) is ReturningHome
 
-    failure_event_handler = current_state.get_event_handler_by_name(
-        "mission_failed_event"
+    failure_event_handler = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed
     )
 
     transition = failure_event_handler.handler(
@@ -106,8 +106,8 @@ def test_intervention_needed_transitions_does_not_transition_if_status_is_not_ho
 ) -> None:
     current_state = InterventionNeeded(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_status_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.robot_status_update
     )
 
     statuses = [

--- a/tests/isar/state_machine/states/test_intervention_needed_state.py
+++ b/tests/isar/state_machine/states/test_intervention_needed_state.py
@@ -5,6 +5,7 @@ from isar.state_machine.states.going_to_lockdown import GoingToLockdown
 from isar.state_machine.states.going_to_recharging import GoingToRecharging
 from isar.state_machine.states.intervention_needed import InterventionNeeded
 from isar.state_machine.states.returning_home import ReturningHome
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 from robot_interface.models.mission.status import RobotStatus
 
@@ -23,7 +24,7 @@ def test_going_to_recharging_goes_to_intervention_needed(events: Events) -> None
     )
 
     current_state = transition(events)
-    assert type(current_state) is InterventionNeeded
+    assert current_state.name is States.InterventionNeeded
 
 
 def test_going_to_lockdown_task_failed_transitions_to_intervention_needed(
@@ -43,7 +44,7 @@ def test_going_to_lockdown_task_failed_transitions_to_intervention_needed(
     )
 
     current_state = transition(events)
-    assert type(current_state) is InterventionNeeded
+    assert current_state.name is States.InterventionNeeded
 
 
 def test_going_to_lockdown_mission_failed_transitions_to_intervention_needed(
@@ -61,7 +62,7 @@ def test_going_to_lockdown_mission_failed_transitions_to_intervention_needed(
     )
 
     current_state = transition(events)
-    assert type(current_state) is InterventionNeeded
+    assert current_state.name is States.InterventionNeeded
 
 
 def test_state_machine_with_return_home_failure(events: Events) -> None:
@@ -84,7 +85,7 @@ def test_state_machine_with_return_home_failure(events: Events) -> None:
 
         assert transition is not None  # type: ignore
         current_state = transition(events)
-        assert type(current_state) is ReturningHome
+        assert current_state.name is States.ReturningHome
 
     failure_event_handler = current_state.get_event_handler_by_event(
         events.robot_service_events.mission_failed
@@ -98,7 +99,7 @@ def test_state_machine_with_return_home_failure(events: Events) -> None:
     )
 
     current_state = transition(events)
-    assert type(current_state) is InterventionNeeded
+    assert current_state.name is States.InterventionNeeded
 
 
 def test_intervention_needed_transitions_does_not_transition_if_status_is_not_home(

--- a/tests/isar/state_machine/states/test_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_lockdown_state.py
@@ -9,8 +9,8 @@ from isar.state_machine.states.stopping_go_to_lockdown import StoppingGoToLockdo
 def test_mission_stopped_when_going_to_lockdown(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "send_to_lockdown_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.send_to_lockdown.request
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -22,8 +22,8 @@ def test_mission_stopped_when_going_to_lockdown(events: Events) -> None:
 def test_going_to_lockdown_transitions_to_lockdown(events: Events) -> None:
     current_state = GoingToLockdown(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "mission_succeeded_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_succeeded
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_lockdown_state.py
@@ -1,9 +1,8 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.going_to_lockdown import GoingToLockdown
-from isar.state_machine.states.lockdown import Lockdown
 from isar.state_machine.states.monitor import Monitor
-from isar.state_machine.states.stopping_go_to_lockdown import StoppingGoToLockdown
+from isar.state_machine.states_enum import States
 
 
 def test_mission_stopped_when_going_to_lockdown(events: Events) -> None:
@@ -16,7 +15,7 @@ def test_mission_stopped_when_going_to_lockdown(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is StoppingGoToLockdown
+    assert current_state.name is States.StoppingGoToLockdown
 
 
 def test_going_to_lockdown_transitions_to_lockdown(events: Events) -> None:
@@ -29,4 +28,4 @@ def test_going_to_lockdown_transitions_to_lockdown(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Lockdown
+    assert current_state.name is States.Lockdown

--- a/tests/isar/state_machine/states/test_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_lockdown_state.py
@@ -9,11 +9,9 @@ from isar.state_machine.states.stopping_go_to_lockdown import StoppingGoToLockdo
 def test_mission_stopped_when_going_to_lockdown(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "send_to_lockdown_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -24,11 +22,9 @@ def test_mission_stopped_when_going_to_lockdown(events: Events) -> None:
 def test_going_to_lockdown_transitions_to_lockdown(events: Events) -> None:
     current_state = GoingToLockdown(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "mission_succeeded_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_maintenance_mode_state.py
+++ b/tests/isar/state_machine/states/test_maintenance_mode_state.py
@@ -12,8 +12,8 @@ def test_home_transitions_to_maintenance_mode_when_teleoperating(
 ) -> None:
     current_state = Home(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_status_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
@@ -29,8 +29,8 @@ def test_unknown_status_transitions_to_maintenance_mode_when_teleoperating(
 ) -> None:
     current_state = UnknownStatus(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_status_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
@@ -46,8 +46,8 @@ def test_offline_transitions_to_maintenance_mode_when_teleoperating(
 ) -> None:
     current_state = Offline(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_status_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)

--- a/tests/isar/state_machine/states/test_maintenance_mode_state.py
+++ b/tests/isar/state_machine/states/test_maintenance_mode_state.py
@@ -12,10 +12,9 @@ def test_home_transitions_to_maintenance_mode_when_teleoperating(
 ) -> None:
     current_state = Home(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_status_event"
     )
-    assert event_handler is not None
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
 
@@ -30,10 +29,9 @@ def test_unknown_status_transitions_to_maintenance_mode_when_teleoperating(
 ) -> None:
     current_state = UnknownStatus(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_status_event"
     )
-    assert event_handler is not None
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
 
@@ -48,10 +46,9 @@ def test_offline_transitions_to_maintenance_mode_when_teleoperating(
 ) -> None:
     current_state = Offline(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_status_event"
     )
-    assert event_handler is not None
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
 

--- a/tests/isar/state_machine/states/test_maintenance_mode_state.py
+++ b/tests/isar/state_machine/states/test_maintenance_mode_state.py
@@ -1,9 +1,9 @@
 from isar.models.events import Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.home import Home
-from isar.state_machine.states.maintenance import Maintenance
 from isar.state_machine.states.offline import Offline
 from isar.state_machine.states.unknown_status import UnknownStatus
+from isar.state_machine.states_enum import States
 from robot_interface.models.mission.status import RobotStatus
 
 
@@ -21,7 +21,7 @@ def test_home_transitions_to_maintenance_mode_when_teleoperating(
     assert transition is not None
 
     current_state = transition(events)
-    assert type(current_state) is Maintenance
+    assert current_state.name is States.Maintenance
 
 
 def test_unknown_status_transitions_to_maintenance_mode_when_teleoperating(
@@ -38,7 +38,7 @@ def test_unknown_status_transitions_to_maintenance_mode_when_teleoperating(
     assert transition is not None
 
     current_state = transition(events)
-    assert type(current_state) is Maintenance
+    assert current_state.name is States.Maintenance
 
 
 def test_offline_transitions_to_maintenance_mode_when_teleoperating(
@@ -55,4 +55,4 @@ def test_offline_transitions_to_maintenance_mode_when_teleoperating(
     assert transition is not None
 
     current_state = transition(events)
-    assert type(current_state) is Maintenance
+    assert current_state.name is States.Maintenance

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -47,8 +47,8 @@ def _mock_robot_exception_with_message() -> RobotException:
 
 def test_stopping_to_recharge_goes_to_intervention_needed(events: Events) -> None:
     current_state = StoppingGoToRecharge(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_stop
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -65,8 +65,8 @@ def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(
     example_mission: Mission = ReturnHomeMission()
     current_state = StoppingReturnHome(events, example_mission)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_stopped
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -78,8 +78,8 @@ def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(
 def test_stopping_lockdown_failing_to_monitor(events: Events) -> None:
     current_state = StoppingGoToLockdown(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_stop
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -95,8 +95,8 @@ def test_stopping_lockdown_failing_to_monitor(events: Events) -> None:
 def test_transition_from_pausing_to_monitor(events: Events) -> None:
     current_state = Pausing(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_pause_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_pause
     )
 
     error_event = ErrorMessage(
@@ -111,8 +111,8 @@ def test_transition_from_pausing_to_monitor(events: Events) -> None:
 def test_transition_from_resuming_to_monitor(events: Events) -> None:
     current_state = Resuming(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_resume_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_resumed
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -259,8 +259,8 @@ def test_robot_mission_status_exception_handling(
 def test_transition_from_monitor_to_stopping_to_recharge(events: Events) -> None:
     current_state = Monitor(events, "test_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_battery_below_threshold_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -11,7 +11,6 @@ from isar.models.events import EmptyMessage, Events
 from isar.modules import ApplicationContainer
 from isar.services.utilities.scheduling_utilities import SchedulingUtilities
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.intervention_needed import InterventionNeeded
 from isar.state_machine.states.monitor import Monitor
 from isar.state_machine.states.pausing import Pausing
 from isar.state_machine.states.resuming import Resuming
@@ -56,7 +55,7 @@ def test_stopping_to_recharge_goes_to_intervention_needed(events: Events) -> Non
     current_state = transition(events)
 
     assert not events.mqtt_queue.empty()
-    assert type(current_state) is InterventionNeeded
+    assert current_state.name is States.InterventionNeeded
 
 
 def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(
@@ -72,7 +71,7 @@ def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(
     transition = event_handler.handler(EmptyMessage())
     current_state = transition(events)
 
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor
 
 
 def test_stopping_lockdown_failing_to_monitor(events: Events) -> None:
@@ -89,7 +88,7 @@ def test_stopping_lockdown_failing_to_monitor(events: Events) -> None:
     assert events.mqtt_queue.empty()
 
     current_state = transition(events)
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor
 
 
 def test_transition_from_pausing_to_monitor(events: Events) -> None:
@@ -105,7 +104,7 @@ def test_transition_from_pausing_to_monitor(events: Events) -> None:
     transition = event_handler.handler(error_event)
 
     current_state = transition(events)
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor
 
 
 def test_transition_from_resuming_to_monitor(events: Events) -> None:
@@ -118,7 +117,7 @@ def test_transition_from_resuming_to_monitor(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor
 
 
 def test_state_machine_with_unsuccessful_mission_stop(
@@ -267,6 +266,6 @@ def test_transition_from_monitor_to_stopping_to_recharge(events: Events) -> None
 
     current_state = transition(events)
 
-    assert type(current_state) is StoppingGoToRecharge
+    assert current_state.name is States.StoppingGoToRecharge
     assert not events.api_requests.stop_mission.response.has_event()
     assert events.state_machine_events.stop_mission.has_event()

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -47,11 +47,9 @@ def _mock_robot_exception_with_message() -> RobotException:
 
 def test_stopping_to_recharge_goes_to_intervention_needed(events: Events) -> None:
     current_state = StoppingGoToRecharge(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -67,11 +65,9 @@ def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(
     example_mission: Mission = ReturnHomeMission()
     current_state = StoppingReturnHome(events, example_mission)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
     current_state = transition(events)
@@ -82,11 +78,9 @@ def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(
 def test_stopping_lockdown_failing_to_monitor(events: Events) -> None:
     current_state = StoppingGoToLockdown(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -101,11 +95,9 @@ def test_stopping_lockdown_failing_to_monitor(events: Events) -> None:
 def test_transition_from_pausing_to_monitor(events: Events) -> None:
     current_state = Pausing(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_pause_event"
     )
-
-    assert event_handler is not None
 
     error_event = ErrorMessage(
         error_reason=ErrorReason.RobotUnknownErrorException, error_description=""
@@ -119,11 +111,9 @@ def test_transition_from_pausing_to_monitor(events: Events) -> None:
 def test_transition_from_resuming_to_monitor(events: Events) -> None:
     current_state = Resuming(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_resume_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -269,11 +259,9 @@ def test_robot_mission_status_exception_handling(
 def test_transition_from_monitor_to_stopping_to_recharge(events: Events) -> None:
     current_state = Monitor(events, "test_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_battery_below_threshold_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_paused_state.py
+++ b/tests/isar/state_machine/states/test_paused_state.py
@@ -9,11 +9,9 @@ from isar.state_machine.states.stopping_paused_mission import StoppingPausedMiss
 def test_transition_from_pausing_to_paused(events: Events) -> None:
     current_state = Pausing(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_pause_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -24,11 +22,9 @@ def test_transition_from_pausing_to_paused(events: Events) -> None:
 def test_transition_from_paused_to_stopping_paused_mission(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "stop_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler("test_id")
 
@@ -41,11 +37,9 @@ def test_transition_from_paused_to_stopping_paused_mission(events: Events) -> No
 def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_battery_below_threshold_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -59,11 +53,9 @@ def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
 def test_stop_request_with_wrong_id_in_paused(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "stop_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler("wrong_test_id")
 

--- a/tests/isar/state_machine/states/test_paused_state.py
+++ b/tests/isar/state_machine/states/test_paused_state.py
@@ -9,8 +9,8 @@ from isar.state_machine.states.stopping_paused_mission import StoppingPausedMiss
 def test_transition_from_pausing_to_paused(events: Events) -> None:
     current_state = Pausing(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_pause_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_paused
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -22,8 +22,8 @@ def test_transition_from_pausing_to_paused(events: Events) -> None:
 def test_transition_from_paused_to_stopping_paused_mission(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "stop_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.stop_mission.request
     )
 
     transition = event_handler.handler("test_id")
@@ -37,8 +37,8 @@ def test_transition_from_paused_to_stopping_paused_mission(events: Events) -> No
 def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_battery_below_threshold_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -53,8 +53,8 @@ def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
 def test_stop_request_with_wrong_id_in_paused(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "stop_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.stop_mission.request
     )
 
     transition = event_handler.handler("wrong_test_id")

--- a/tests/isar/state_machine/states/test_paused_state.py
+++ b/tests/isar/state_machine/states/test_paused_state.py
@@ -2,8 +2,7 @@ from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.paused import Paused
 from isar.state_machine.states.pausing import Pausing
-from isar.state_machine.states.stopping_go_to_recharge import StoppingGoToRecharge
-from isar.state_machine.states.stopping_paused_mission import StoppingPausedMission
+from isar.state_machine.states_enum import States
 
 
 def test_transition_from_pausing_to_paused(events: Events) -> None:
@@ -16,7 +15,7 @@ def test_transition_from_pausing_to_paused(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Paused
+    assert current_state.name is States.Paused
 
 
 def test_transition_from_paused_to_stopping_paused_mission(events: Events) -> None:
@@ -30,7 +29,7 @@ def test_transition_from_paused_to_stopping_paused_mission(events: Events) -> No
 
     current_state = transition(events)
 
-    assert type(current_state) is StoppingPausedMission
+    assert current_state.name is States.StoppingPausedMission
     assert events.api_requests.stop_mission.response.has_event()
 
 
@@ -45,7 +44,7 @@ def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
 
     current_state = transition(events)
 
-    assert type(current_state) is StoppingGoToRecharge
+    assert current_state.name is States.StoppingGoToRecharge
     assert not events.api_requests.stop_mission.response.has_event()
     assert events.state_machine_events.stop_mission.has_event()
 

--- a/tests/isar/state_machine/states/test_pausing_return_home_state.py
+++ b/tests/isar/state_machine/states/test_pausing_return_home_state.py
@@ -7,11 +7,9 @@ from isar.state_machine.states.returning_home import ReturningHome
 def test_transition_from_returning_home_to_pausing_return_home(events: Events) -> None:
     current_state = ReturningHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "pause_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_pausing_return_home_state.py
+++ b/tests/isar/state_machine/states/test_pausing_return_home_state.py
@@ -1,7 +1,7 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.pausing_return_home import PausingReturnHome
 from isar.state_machine.states.returning_home import ReturningHome
+from isar.state_machine.states_enum import States
 
 
 def test_transition_from_returning_home_to_pausing_return_home(events: Events) -> None:
@@ -14,4 +14,4 @@ def test_transition_from_returning_home_to_pausing_return_home(events: Events) -
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is PausingReturnHome
+    assert current_state.name is States.PausingReturnHome

--- a/tests/isar/state_machine/states/test_pausing_return_home_state.py
+++ b/tests/isar/state_machine/states/test_pausing_return_home_state.py
@@ -7,8 +7,8 @@ from isar.state_machine.states.returning_home import ReturningHome
 def test_transition_from_returning_home_to_pausing_return_home(events: Events) -> None:
     current_state = ReturningHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "pause_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.pause_mission.request
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_pausing_state.py
+++ b/tests/isar/state_machine/states/test_pausing_state.py
@@ -1,7 +1,7 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.monitor import Monitor
-from isar.state_machine.states.pausing import Pausing
+from isar.state_machine.states_enum import States
 
 
 def test_transition_from_monitor_to_pausing(events: Events) -> None:
@@ -14,4 +14,4 @@ def test_transition_from_monitor_to_pausing(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Pausing
+    assert current_state.name is States.Pausing

--- a/tests/isar/state_machine/states/test_pausing_state.py
+++ b/tests/isar/state_machine/states/test_pausing_state.py
@@ -7,11 +7,9 @@ from isar.state_machine.states.pausing import Pausing
 def test_transition_from_monitor_to_pausing(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "pause_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_pausing_state.py
+++ b/tests/isar/state_machine/states/test_pausing_state.py
@@ -7,8 +7,8 @@ from isar.state_machine.states.pausing import Pausing
 def test_transition_from_monitor_to_pausing(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "pause_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.pause_mission.request
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -9,8 +9,8 @@ from isar.state_machine.states.recharging_with_mission import RechargingWithMiss
 
 def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
     current_state = GoingToRecharging(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "mission_succeeded_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_succeeded
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -21,8 +21,8 @@ def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
 
 def test_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = Home(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_battery_below_threshold_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -35,8 +35,8 @@ def test_continuing_mission_when_battery_high(events: Events) -> None:
     current_state = RechargingWithMission(
         events, mission=AbortedMission(name="test", id="test_id")
     )
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_battery_above_recharging_threshold_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.battery_above_recharge_threshold_event
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -49,8 +49,8 @@ def test_cancelling_mission_when_recharging_with_mission(events: Events) -> None
     current_state = RechargingWithMission(
         events, mission=AbortedMission(name="test", id="test_id")
     )
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "stop_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.stop_mission.request
     )
 
     transition = event_handler.handler("test_id")

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -2,9 +2,8 @@ from isar.models.events import AbortedMission, EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.going_to_recharging import GoingToRecharging
 from isar.state_machine.states.home import Home
-from isar.state_machine.states.monitor import Monitor
-from isar.state_machine.states.recharging import Recharging
 from isar.state_machine.states.recharging_with_mission import RechargingWithMission
+from isar.state_machine.states_enum import States
 
 
 def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
@@ -16,7 +15,7 @@ def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Recharging
+    assert current_state.name is States.Recharging
 
 
 def test_home_goes_to_recharging_when_battery_low(events: Events) -> None:
@@ -28,7 +27,7 @@ def test_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Recharging
+    assert current_state.name is States.Recharging
 
 
 def test_continuing_mission_when_battery_high(events: Events) -> None:
@@ -42,7 +41,7 @@ def test_continuing_mission_when_battery_high(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor
 
 
 def test_cancelling_mission_when_recharging_with_mission(events: Events) -> None:
@@ -56,4 +55,4 @@ def test_cancelling_mission_when_recharging_with_mission(events: Events) -> None
     transition = event_handler.handler("test_id")
 
     current_state = transition(events)
-    assert type(current_state) is Recharging
+    assert current_state.name is States.Recharging

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -36,7 +36,7 @@ def test_continuing_mission_when_battery_high(events: Events) -> None:
         events, mission=AbortedMission(name="test", id="test_id")
     )
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_above_recharge_threshold_event
+        events.robot_service_events.battery_above_recharge_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -9,11 +9,9 @@ from isar.state_machine.states.recharging_with_mission import RechargingWithMiss
 
 def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
     current_state = GoingToRecharging(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "mission_succeeded_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -23,11 +21,9 @@ def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
 
 def test_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = Home(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_battery_below_threshold_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -39,11 +35,9 @@ def test_continuing_mission_when_battery_high(events: Events) -> None:
     current_state = RechargingWithMission(
         events, mission=AbortedMission(name="test", id="test_id")
     )
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_battery_above_recharging_threshold_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -55,11 +49,9 @@ def test_cancelling_mission_when_recharging_with_mission(events: Events) -> None
     current_state = RechargingWithMission(
         events, mission=AbortedMission(name="test", id="test_id")
     )
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "stop_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler("test_id")
 

--- a/tests/isar/state_machine/states/test_resuming_return_home_state.py
+++ b/tests/isar/state_machine/states/test_resuming_return_home_state.py
@@ -9,8 +9,8 @@ def test_transition_from_return_home_paused_to_resuming_return_home(
 ) -> None:
     current_state = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "resume_return_home_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.resume_mission.request
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_resuming_return_home_state.py
+++ b/tests/isar/state_machine/states/test_resuming_return_home_state.py
@@ -1,7 +1,7 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.resuming_return_home import ResumingReturnHome
 from isar.state_machine.states.return_home_paused import ReturnHomePaused
+from isar.state_machine.states_enum import States
 
 
 def test_transition_from_return_home_paused_to_resuming_return_home(
@@ -16,4 +16,4 @@ def test_transition_from_return_home_paused_to_resuming_return_home(
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is ResumingReturnHome
+    assert current_state.name is States.ResumingReturnHome

--- a/tests/isar/state_machine/states/test_resuming_return_home_state.py
+++ b/tests/isar/state_machine/states/test_resuming_return_home_state.py
@@ -9,11 +9,9 @@ def test_transition_from_return_home_paused_to_resuming_return_home(
 ) -> None:
     current_state = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "resume_return_home_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_resuming_state.py
+++ b/tests/isar/state_machine/states/test_resuming_state.py
@@ -7,11 +7,9 @@ from isar.state_machine.states.resuming import Resuming
 def test_transition_from_paused_to_resuming(events: Events) -> None:
     current_state = Paused(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "resume_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_resuming_state.py
+++ b/tests/isar/state_machine/states/test_resuming_state.py
@@ -1,7 +1,7 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.paused import Paused
-from isar.state_machine.states.resuming import Resuming
+from isar.state_machine.states_enum import States
 
 
 def test_transition_from_paused_to_resuming(events: Events) -> None:
@@ -14,4 +14,4 @@ def test_transition_from_paused_to_resuming(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Resuming
+    assert current_state.name is States.Resuming

--- a/tests/isar/state_machine/states/test_resuming_state.py
+++ b/tests/isar/state_machine/states/test_resuming_state.py
@@ -7,8 +7,8 @@ from isar.state_machine.states.resuming import Resuming
 def test_transition_from_paused_to_resuming(events: Events) -> None:
     current_state = Paused(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "resume_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.resume_mission.request
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_return_home_paused_state.py
+++ b/tests/isar/state_machine/states/test_return_home_paused_state.py
@@ -15,8 +15,8 @@ def test_transition_from_pausing_return_home_to_return_home_paused(
 ) -> None:
     current_state = PausingReturnHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_pause_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_paused
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -28,8 +28,8 @@ def test_transition_from_pausing_return_home_to_return_home_paused(
 def test_resuming_paused_return_home(events: Events) -> None:
     current_state = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "resume_return_home_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.resume_mission.request
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -43,8 +43,8 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
 ) -> None:
     current_state = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "start_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.start_mission.request
     )
 
     example_mission: Mission = Mission(id="id", name="Dummy misson", tasks=[])
@@ -60,8 +60,8 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
 def test_stop_request_with_wrong_id_in_paused(events: Events) -> None:
     current_state = Paused(events, "mission_id")
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "stop_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.stop_mission.request
     )
 
     transition = event_handler.handler("wrong_test_id")

--- a/tests/isar/state_machine/states/test_return_home_paused_state.py
+++ b/tests/isar/state_machine/states/test_return_home_paused_state.py
@@ -2,11 +2,8 @@ from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.paused import Paused
 from isar.state_machine.states.pausing_return_home import PausingReturnHome
-from isar.state_machine.states.resuming_return_home import ResumingReturnHome
 from isar.state_machine.states.return_home_paused import ReturnHomePaused
-from isar.state_machine.states.stopping_paused_return_home import (
-    StoppingPausedReturnHome,
-)
+from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 
 
@@ -22,7 +19,7 @@ def test_transition_from_pausing_return_home_to_return_home_paused(
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is ReturnHomePaused
+    assert current_state.name is States.ReturnHomePaused
 
 
 def test_resuming_paused_return_home(events: Events) -> None:
@@ -35,7 +32,7 @@ def test_resuming_paused_return_home(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is ResumingReturnHome
+    assert current_state.name is States.ResumingReturnHome
 
 
 def test_transition_from_paused_return_home_to_stopping_paused_return_home_mission(
@@ -54,7 +51,7 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
     current_state = transition(events)
 
     assert events.api_requests.start_mission.response.has_event()
-    assert type(current_state) is StoppingPausedReturnHome
+    assert current_state.name is States.StoppingPausedReturnHome
 
 
 def test_stop_request_with_wrong_id_in_paused(events: Events) -> None:

--- a/tests/isar/state_machine/states/test_return_home_paused_state.py
+++ b/tests/isar/state_machine/states/test_return_home_paused_state.py
@@ -15,11 +15,9 @@ def test_transition_from_pausing_return_home_to_return_home_paused(
 ) -> None:
     current_state = PausingReturnHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_pause_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -30,11 +28,9 @@ def test_transition_from_pausing_return_home_to_return_home_paused(
 def test_resuming_paused_return_home(events: Events) -> None:
     current_state = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "resume_return_home_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -47,11 +43,9 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
 ) -> None:
     current_state = ReturnHomePaused(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "start_mission_event"
     )
-
-    assert event_handler is not None
 
     example_mission: Mission = Mission(id="id", name="Dummy misson", tasks=[])
 
@@ -66,11 +60,9 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
 def test_stop_request_with_wrong_id_in_paused(events: Events) -> None:
     current_state = Paused(events, "mission_id")
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "stop_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler("wrong_test_id")
 

--- a/tests/isar/state_machine/states/test_returning_home_state.py
+++ b/tests/isar/state_machine/states/test_returning_home_state.py
@@ -17,8 +17,8 @@ def test_transitioning_to_returning_home_from_stopping_when_return_home_failed(
     example_mission: Mission = ReturnHomeMission()
     current_state = StoppingReturnHome(events, example_mission)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_stopped
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -30,8 +30,8 @@ def test_transitioning_to_returning_home_from_stopping_when_return_home_failed(
 def test_transition_from_pausing_return_home_to_returning_home(events: Events) -> None:
     current_state = PausingReturnHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_pause_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_pause
     )
 
     error_event = ErrorMessage(
@@ -48,8 +48,8 @@ def test_transition_from_resuming_return_home_to_returning_home_state(
 ) -> None:
     current_state = ResumingReturnHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_resume_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_resumed
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -63,8 +63,8 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
 ) -> None:
     current_state: State = ReturningHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "mission_succeeded_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_succeeded
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -74,7 +74,9 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
     assert not events.robot_service_events.robot_status_update.check()
 
     event_handler_robot_status: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("robot_status_event")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.robot_status_update
+        )
     )
 
     assert not event_handler_robot_status.event.has_event()

--- a/tests/isar/state_machine/states/test_returning_home_state.py
+++ b/tests/isar/state_machine/states/test_returning_home_state.py
@@ -1,12 +1,11 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping, State, TimeoutHandlerMapping
 from isar.state_machine.states.await_next_mission import AwaitNextMission
-from isar.state_machine.states.home import Home
-from isar.state_machine.states.monitor import Monitor
 from isar.state_machine.states.pausing_return_home import PausingReturnHome
 from isar.state_machine.states.resuming_return_home import ResumingReturnHome
 from isar.state_machine.states.returning_home import ReturningHome
 from isar.state_machine.states.stopping_return_home import StoppingReturnHome
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 from robot_interface.models.mission.mission import Mission, ReturnHomeMission
 
@@ -24,7 +23,7 @@ def test_transitioning_to_returning_home_from_stopping_when_return_home_failed(
     transition = event_handler.handler(EmptyMessage())
     current_state = transition(events)
 
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor
 
 
 def test_transition_from_pausing_return_home_to_returning_home(events: Events) -> None:
@@ -40,7 +39,7 @@ def test_transition_from_pausing_return_home_to_returning_home(events: Events) -
     transition = event_handler.handler(error_event)
 
     current_state = transition(events)
-    assert type(current_state) is ReturningHome
+    assert current_state.name is States.ReturningHome
 
 
 def test_transition_from_resuming_return_home_to_returning_home_state(
@@ -55,7 +54,7 @@ def test_transition_from_resuming_return_home_to_returning_home_state(
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is ReturningHome
+    assert current_state.name is States.ReturningHome
 
 
 def test_transition_from_returning_home_to_home_robot_status_not_updated(
@@ -70,7 +69,7 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Home
+    assert current_state.name is States.Home
     assert not events.robot_service_events.robot_status_update.check()
 
     event_handler_robot_status: EventHandlerMapping = (
@@ -93,4 +92,4 @@ def test_return_home_starts_when_battery_is_low(events: Events) -> None:
 
     current_state = transition(events)
 
-    assert type(current_state) is ReturningHome
+    assert current_state.name is States.ReturningHome

--- a/tests/isar/state_machine/states/test_returning_home_state.py
+++ b/tests/isar/state_machine/states/test_returning_home_state.py
@@ -17,11 +17,9 @@ def test_transitioning_to_returning_home_from_stopping_when_return_home_failed(
     example_mission: Mission = ReturnHomeMission()
     current_state = StoppingReturnHome(events, example_mission)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
     current_state = transition(events)
@@ -32,11 +30,9 @@ def test_transitioning_to_returning_home_from_stopping_when_return_home_failed(
 def test_transition_from_pausing_return_home_to_returning_home(events: Events) -> None:
     current_state = PausingReturnHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_pause_event"
     )
-
-    assert event_handler is not None
 
     error_event = ErrorMessage(
         error_reason=ErrorReason.RobotUnknownErrorException, error_description=""
@@ -52,11 +48,9 @@ def test_transition_from_resuming_return_home_to_returning_home_state(
 ) -> None:
     current_state = ResumingReturnHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_resume_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -69,11 +63,9 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
 ) -> None:
     current_state: State = ReturningHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "mission_succeeded_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -81,11 +73,9 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
     assert type(current_state) is Home
     assert not events.robot_service_events.robot_status_update.check()
 
-    event_handler_robot_status: EventHandlerMapping | None = (
+    event_handler_robot_status: EventHandlerMapping = (
         current_state.get_event_handler_by_name("robot_status_event")
     )
-
-    assert event_handler_robot_status is not None
 
     assert not event_handler_robot_status.event.has_event()
 
@@ -93,11 +83,9 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
 def test_return_home_starts_when_battery_is_low(events: Events) -> None:
     current_state = AwaitNextMission(events)
 
-    timer: TimeoutHandlerMapping | None = current_state.get_event_timer_by_name(
+    timer: TimeoutHandlerMapping = current_state.get_event_timer_by_name(
         "should_return_home_timer"
     )
-
-    assert timer is not None
 
     transition = timer.handler()
 

--- a/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
+++ b/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
@@ -6,8 +6,8 @@ from isar.state_machine.states.stopping_go_to_recharge import StoppingGoToRechar
 
 def test_monitor_goes_to_return_home_when_battery_low(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_battery_below_threshold_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
+++ b/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
@@ -6,11 +6,9 @@ from isar.state_machine.states.stopping_go_to_recharge import StoppingGoToRechar
 
 def test_monitor_goes_to_return_home_when_battery_low(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_battery_below_threshold_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
+++ b/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
@@ -1,7 +1,7 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
 from isar.state_machine.states.monitor import Monitor
-from isar.state_machine.states.stopping_go_to_recharge import StoppingGoToRecharge
+from isar.state_machine.states_enum import States
 
 
 def test_monitor_goes_to_return_home_when_battery_low(events: Events) -> None:
@@ -13,4 +13,4 @@ def test_monitor_goes_to_return_home_when_battery_low(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is StoppingGoToRecharge
+    assert current_state.name is States.StoppingGoToRecharge

--- a/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
@@ -8,11 +8,9 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, Err
 
 def test_stopping_paused_mission_fails(events: Events) -> None:
     current_state = StoppingPausedMission(events, "mission_id")
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(error_description="", error_reason=ErrorReason.RobotAPIException)
@@ -26,11 +24,9 @@ def test_stopping_paused_mission_fails(events: Events) -> None:
 
 def test_stopping_paused_mission_succeeds(events: Events) -> None:
     current_state = StoppingPausedMission(events, "mission_id")
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
@@ -8,8 +8,8 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, Err
 
 def test_stopping_paused_mission_fails(events: Events) -> None:
     current_state = StoppingPausedMission(events, "mission_id")
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_stop
     )
 
     transition = event_handler.handler(
@@ -24,8 +24,8 @@ def test_stopping_paused_mission_fails(events: Events) -> None:
 
 def test_stopping_paused_mission_succeeds(events: Events) -> None:
     current_state = StoppingPausedMission(events, "mission_id")
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_stopped
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
@@ -1,8 +1,7 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.await_next_mission import AwaitNextMission
-from isar.state_machine.states.paused import Paused
 from isar.state_machine.states.stopping_paused_mission import StoppingPausedMission
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 
 
@@ -19,7 +18,7 @@ def test_stopping_paused_mission_fails(events: Events) -> None:
     assert events.mqtt_queue.empty()
 
     current_state = transition(events)
-    assert type(current_state) is Paused
+    assert current_state.name is States.Paused
 
 
 def test_stopping_paused_mission_succeeds(events: Events) -> None:
@@ -33,4 +32,4 @@ def test_stopping_paused_mission_succeeds(events: Events) -> None:
     assert events.mqtt_queue.qsize() == 1
 
     current_state = transition(events)
-    assert type(current_state) is AwaitNextMission
+    assert current_state.name is States.AwaitNextMission

--- a/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
@@ -16,8 +16,8 @@ def test_transition_to_stopping_paused_return_home_replies_to_API(
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = ReturnHomePaused(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "start_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.start_mission.request
     )
 
     transition = event_handler.handler(mission)
@@ -32,8 +32,8 @@ def test_stopping_paused_return_home_mission_fails(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingPausedReturnHome(events, mission)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_stop
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -49,8 +49,8 @@ def test_stopping_paused_return_home_mission_succeeds(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingPausedReturnHome(events, mission)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_stopped
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
@@ -1,10 +1,10 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.monitor import Monitor
 from isar.state_machine.states.return_home_paused import ReturnHomePaused
 from isar.state_machine.states.stopping_paused_return_home import (
     StoppingPausedReturnHome,
 )
+from isar.state_machine.states_enum import States
 from robot_interface.models.mission.mission import Mission
 from tests.test_mocks.task import StubTask
 
@@ -23,7 +23,7 @@ def test_transition_to_stopping_paused_return_home_replies_to_API(
     transition = event_handler.handler(mission)
 
     current_state = transition(events)
-    assert type(current_state) is StoppingPausedReturnHome
+    assert current_state.name is States.StoppingPausedReturnHome
     assert events.api_requests.start_mission.response.has_event()
 
 
@@ -41,7 +41,7 @@ def test_stopping_paused_return_home_mission_fails(events: Events) -> None:
     assert not events.api_requests.start_mission.response.has_event()
 
     current_state = transition(events)
-    assert type(current_state) is ReturnHomePaused
+    assert current_state.name is States.ReturnHomePaused
 
 
 def test_stopping_paused_return_home_mission_succeeds(events: Events) -> None:
@@ -56,4 +56,4 @@ def test_stopping_paused_return_home_mission_succeeds(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor

--- a/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
@@ -16,11 +16,9 @@ def test_transition_to_stopping_paused_return_home_replies_to_API(
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = ReturnHomePaused(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "start_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(mission)
 
@@ -34,11 +32,9 @@ def test_stopping_paused_return_home_mission_fails(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingPausedReturnHome(events, mission)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 
@@ -53,11 +49,9 @@ def test_stopping_paused_return_home_mission_succeeds(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingPausedReturnHome(events, mission)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_stopping_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_return_home_state.py
@@ -11,8 +11,8 @@ from tests.test_mocks.task import StubTask
 def test_return_home_cancelled_when_new_mission_received(events: Events) -> None:
     current_state = ReturningHome(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "start_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.start_mission.request
     )
 
     mission: Mission = Mission(
@@ -30,8 +30,8 @@ def test_transition_to_stopping_return_home_replies_to_API(events: Events) -> No
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = ReturningHome(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "start_mission_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.api_requests.start_mission.request
     )
 
     transition = event_handler.handler(mission)
@@ -46,8 +46,8 @@ def test_stopping_return_home_mission_fails(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingReturnHome(events, mission)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_stop
     )
 
     transition = event_handler.handler(
@@ -65,8 +65,8 @@ def test_stopping_return_home_mission_succeeds(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingReturnHome(events, mission)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "successful_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_successfully_stopped
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_return_home_state.py
@@ -11,15 +11,13 @@ from tests.test_mocks.task import StubTask
 def test_return_home_cancelled_when_new_mission_received(events: Events) -> None:
     current_state = ReturningHome(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "start_mission_event"
     )
 
     mission: Mission = Mission(
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(mission)
 
@@ -32,11 +30,9 @@ def test_transition_to_stopping_return_home_replies_to_API(events: Events) -> No
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = ReturningHome(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "start_mission_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(mission)
 
@@ -50,11 +46,9 @@ def test_stopping_return_home_mission_fails(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingReturnHome(events, mission)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(error_description="", error_reason=ErrorReason.RobotAPIException)
@@ -71,11 +65,9 @@ def test_stopping_return_home_mission_succeeds(events: Events) -> None:
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
     current_state = StoppingReturnHome(events, mission)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "successful_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(EmptyMessage())
 

--- a/tests/isar/state_machine/states/test_stopping_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_return_home_state.py
@@ -1,8 +1,8 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.monitor import Monitor
 from isar.state_machine.states.returning_home import ReturningHome
 from isar.state_machine.states.stopping_return_home import StoppingReturnHome
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 from robot_interface.models.mission.mission import Mission
 from tests.test_mocks.task import StubTask
@@ -22,7 +22,7 @@ def test_return_home_cancelled_when_new_mission_received(events: Events) -> None
     transition = event_handler.handler(mission)
 
     current_state = transition(events)
-    assert type(current_state) is StoppingReturnHome
+    assert current_state.name is States.StoppingReturnHome
 
 
 def test_transition_to_stopping_return_home_replies_to_API(events: Events) -> None:
@@ -37,7 +37,7 @@ def test_transition_to_stopping_return_home_replies_to_API(events: Events) -> No
     transition = event_handler.handler(mission)
 
     current_state = transition(events)
-    assert type(current_state) is StoppingReturnHome
+    assert current_state.name is States.StoppingReturnHome
     assert events.api_requests.start_mission.response.has_event()
 
 
@@ -57,7 +57,7 @@ def test_stopping_return_home_mission_fails(events: Events) -> None:
     assert not events.api_requests.start_mission.response.has_event()
 
     current_state = transition(events)
-    assert type(current_state) is ReturningHome
+    assert current_state.name is States.ReturningHome
 
 
 def test_stopping_return_home_mission_succeeds(events: Events) -> None:
@@ -72,4 +72,4 @@ def test_stopping_return_home_mission_succeeds(events: Events) -> None:
     transition = event_handler.handler(EmptyMessage())
 
     current_state = transition(events)
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor

--- a/tests/isar/state_machine/states/test_stopping_state.py
+++ b/tests/isar/state_machine/states/test_stopping_state.py
@@ -10,7 +10,9 @@ def test_mqtt_mission_status_sent_on_mission_stopped(events: Events) -> None:
     current_state = Stopping(events, "mission_id")
 
     stopping_state_event_handler: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("successful_stop_event")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.mission_successfully_stopped
+        )
     )
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
@@ -24,8 +26,8 @@ def test_mqtt_mission_status_sent_on_mission_stopped(events: Events) -> None:
 
 def test_stopping_mission_fails(events: Events) -> None:
     current_state = Stopping(events, "mission_id")
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_stop
     )
 
     transition = event_handler.handler(

--- a/tests/isar/state_machine/states/test_stopping_state.py
+++ b/tests/isar/state_machine/states/test_stopping_state.py
@@ -9,10 +9,9 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, Err
 def test_mqtt_mission_status_sent_on_mission_stopped(events: Events) -> None:
     current_state = Stopping(events, "mission_id")
 
-    stopping_state_event_handler: EventHandlerMapping | None = (
+    stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_name("successful_stop_event")
     )
-    assert stopping_state_event_handler is not None
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
 
@@ -25,11 +24,9 @@ def test_mqtt_mission_status_sent_on_mission_stopped(events: Events) -> None:
 
 def test_stopping_mission_fails(events: Events) -> None:
     current_state = Stopping(events, "mission_id")
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(error_description="", error_reason=ErrorReason.RobotAPIException)

--- a/tests/isar/state_machine/states/test_stopping_state.py
+++ b/tests/isar/state_machine/states/test_stopping_state.py
@@ -1,8 +1,7 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping
-from isar.state_machine.states.await_next_mission import AwaitNextMission
-from isar.state_machine.states.monitor import Monitor
 from isar.state_machine.states.stopping import Stopping
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 
 
@@ -21,7 +20,7 @@ def test_mqtt_mission_status_sent_on_mission_stopped(events: Events) -> None:
 
     current_state = transition(events)
 
-    assert type(current_state) is AwaitNextMission
+    assert current_state.name is States.AwaitNextMission
 
 
 def test_stopping_mission_fails(events: Events) -> None:
@@ -37,4 +36,4 @@ def test_stopping_mission_fails(events: Events) -> None:
     assert events.mqtt_queue.empty()
 
     current_state = transition(events)
-    assert type(current_state) is Monitor
+    assert current_state.name is States.Monitor

--- a/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
@@ -12,7 +12,9 @@ def test_unknown_mission_successfully_stopped(events: Events) -> None:
     current_state = StoppingUnknownMission(events)
 
     stopping_state_event_handler: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("successful_stop_event")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.mission_successfully_stopped
+        )
     )
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
@@ -30,7 +32,9 @@ def test_unknown_mission_successfully_stopped_with_no_mission_found(
     current_state = StoppingUnknownMission(events)
 
     stopping_state_event_handler: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("mission_already_done_event")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.stopped_mission_already_done
+        )
     )
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
@@ -45,8 +49,8 @@ def test_unknown_mission_successfully_stopped_with_no_mission_found(
 def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) -> None:
     current_state: State = UnknownStatus(events)
 
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "robot_status_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Busy)
@@ -59,7 +63,9 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
     assert type(current_state) is StoppingUnknownMission
 
     stopping_state_event_handler: EventHandlerMapping = (
-        current_state.get_event_handler_by_name("successful_stop_event")
+        current_state.get_event_handler_by_event(
+            events.robot_service_events.mission_successfully_stopped
+        )
     )
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
@@ -71,8 +77,8 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
 
 def test_stopping_mission_fails(events: Events) -> None:
     current_state = StoppingUnknownMission(events)
-    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
-        "failed_stop_event"
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
+        events.robot_service_events.mission_failed_to_stop
     )
 
     transition = event_handler.handler(

--- a/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
@@ -1,9 +1,8 @@
 from isar.models.events import EmptyMessage, Events
 from isar.state_machine.state import EventHandlerMapping, State
-from isar.state_machine.states.await_next_mission import AwaitNextMission
-from isar.state_machine.states.intervention_needed import InterventionNeeded
 from isar.state_machine.states.stopping_unknown_mission import StoppingUnknownMission
 from isar.state_machine.states.unknown_status import UnknownStatus
+from isar.state_machine.states_enum import States
 from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, ErrorReason
 from robot_interface.models.mission.status import RobotStatus
 
@@ -23,7 +22,7 @@ def test_unknown_mission_successfully_stopped(events: Events) -> None:
 
     current_state = transition(events)
 
-    assert type(current_state) is AwaitNextMission
+    assert current_state.name is States.AwaitNextMission
 
 
 def test_unknown_mission_successfully_stopped_with_no_mission_found(
@@ -43,7 +42,7 @@ def test_unknown_mission_successfully_stopped_with_no_mission_found(
 
     current_state = transition(events)
 
-    assert type(current_state) is AwaitNextMission
+    assert current_state.name is States.AwaitNextMission
 
 
 def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) -> None:
@@ -60,7 +59,7 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
     current_state = transition(events)
 
     assert current_state is not None
-    assert type(current_state) is StoppingUnknownMission
+    assert current_state.name is States.StoppingUnknownMission
 
     stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
@@ -72,7 +71,7 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
 
     current_state = transition(events)
 
-    assert type(current_state) is AwaitNextMission
+    assert current_state.name is States.AwaitNextMission
 
 
 def test_stopping_mission_fails(events: Events) -> None:
@@ -88,4 +87,4 @@ def test_stopping_mission_fails(events: Events) -> None:
     assert events.mqtt_queue.empty()
 
     current_state = transition(events)
-    assert type(current_state) is InterventionNeeded
+    assert current_state.name is States.InterventionNeeded

--- a/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
@@ -11,10 +11,9 @@ from robot_interface.models.mission.status import RobotStatus
 def test_unknown_mission_successfully_stopped(events: Events) -> None:
     current_state = StoppingUnknownMission(events)
 
-    stopping_state_event_handler: EventHandlerMapping | None = (
+    stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_name("successful_stop_event")
     )
-    assert stopping_state_event_handler is not None
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
 
@@ -30,10 +29,9 @@ def test_unknown_mission_successfully_stopped_with_no_mission_found(
 ) -> None:
     current_state = StoppingUnknownMission(events)
 
-    stopping_state_event_handler: EventHandlerMapping | None = (
+    stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_name("mission_already_done_event")
     )
-    assert stopping_state_event_handler is not None
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
 
@@ -47,10 +45,9 @@ def test_unknown_mission_successfully_stopped_with_no_mission_found(
 def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) -> None:
     current_state: State = UnknownStatus(events)
 
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "robot_status_event"
     )
-    assert event_handler is not None
 
     transition = event_handler.handler(RobotStatus.Busy)
 
@@ -61,10 +58,9 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
     assert current_state is not None
     assert type(current_state) is StoppingUnknownMission
 
-    stopping_state_event_handler: EventHandlerMapping | None = (
+    stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_name("successful_stop_event")
     )
-    assert stopping_state_event_handler is not None
 
     transition = stopping_state_event_handler.handler(EmptyMessage())
 
@@ -75,11 +71,9 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
 
 def test_stopping_mission_fails(events: Events) -> None:
     current_state = StoppingUnknownMission(events)
-    event_handler: EventHandlerMapping | None = current_state.get_event_handler_by_name(
+    event_handler: EventHandlerMapping = current_state.get_event_handler_by_name(
         "failed_stop_event"
     )
-
-    assert event_handler is not None
 
     transition = event_handler.handler(
         ErrorMessage(error_description="", error_reason=ErrorReason.RobotAPIException)


### PR DESCRIPTION
This PR moves an assert from each test to the function that the tests use (this function is anyways only used in the tests). The PR also removes the name field from eventhandlermappings since this only added complexity while obscuring the event in the tests themselves. 

It also makes each individual state into a function which returns a State object. The difference between this approach and having each state instance be its own class is that it prevents users from bypassing the state machine framework by implementing new class variables and functions, and also since there is no reason to keep them as separate classes.

The other commits are just minor improvements in the same area of the code.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.