### PR TITLE
Make the MQTT CA certificate configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,13 @@ ISAR_MQTT_PASSWORD
 
 If not specified the password will default to an empty string.
 
+TLS is enabled by default and controlled by `ISAR_MQTT_SSL_ENABLED`. The CA certificate
+verifying the broker is resolved in this order:
+
+1. `ISAR_MQTT_CA_CERT` — the CA certificate inline as PEM.
+2. `ISAR_MQTT_CA_CERT_PATH` — a path to a CA certificate file.
+3. The one bundled in `src/isar/config/certs/ca-cert.pem`.
+
 ## Running several ISAR instances locally
 
 To run several ISAR instances in parallel locally:

--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ verifying the broker is resolved in this order:
 2. `ISAR_MQTT_CA_CERT_PATH` — a path to a CA certificate file.
 3. The one bundled in `src/isar/config/certs/ca-cert.pem`.
 
+Each deployed broker has its own CA, so set `ISAR_MQTT_CA_CERT`; the bundled certificate is a
+fallback that is being phased out. An inline certificate is written to a temporary file,
+because the MQTT client takes a path — the deployments therefore need a writable `/tmp`.
+
 ## Running several ISAR instances locally
 
 To run several ISAR instances in parallel locally:

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -97,6 +97,11 @@ class Settings(BaseSettings):
     # communication.
     MQTT_SSL_ENABLED: bool = Field(default=True)
 
+    # CA certificate verifying the MQTT broker. MQTT_CA_CERT is inline PEM and
+    # takes precedence over MQTT_CA_CERT_PATH; unset, the bundled one is used.
+    MQTT_CA_CERT_PATH: str = Field(default="")
+    MQTT_CA_CERT: str = Field(default="")
+
     # Determines whether authentication is enabled for the API or not
     # Enabling this requires certain resources available for OAuth2 authentication
     # Currently supported authentication is Azure AD

--- a/src/isar/services/service_connections/mqtt/mqtt_client.py
+++ b/src/isar/services/service_connections/mqtt/mqtt_client.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+from tempfile import NamedTemporaryFile
 from typing import Any
 
 import backoff
@@ -68,13 +69,37 @@ class MqttClient:
         dirname = os.path.dirname(__file__)
 
         if settings.MQTT_SSL_ENABLED:
-            cert_path = os.path.join(dirname, "../../../config/certs/ca-cert.pem")
-            self.client.tls_set(ca_certs=cert_path)
+            self.client.tls_set(ca_certs=self._resolve_ca_certificate(dirname))
 
         self.client.on_connect = self.on_connect
         self.client.on_disconnect = self.on_disconnect
 
         self.client.username_pw_set(username=username, password=password)
+
+    def _resolve_ca_certificate(self, dirname: str) -> str:
+        """Determine which CA certificate to verify the broker certificate against.
+
+        Parameters
+        ----------
+        dirname : str
+            Directory of this module, used to locate the bundled certificate.
+
+        Returns
+        -------
+        str
+            Path to the CA certificate to use.
+        """
+        if settings.MQTT_CA_CERT:
+            with NamedTemporaryFile(
+                mode="w", suffix=".pem", delete=False
+            ) as certificate_file:
+                certificate_file.write(settings.MQTT_CA_CERT)
+            return certificate_file.name
+
+        if settings.MQTT_CA_CERT_PATH:
+            return settings.MQTT_CA_CERT_PATH
+
+        return os.path.join(dirname, "../../../config/certs/ca-cert.pem")
 
     def run(self) -> None:
         self.connect(host=self.host, port=self.port)

--- a/src/isar/services/service_connections/mqtt/mqtt_client.py
+++ b/src/isar/services/service_connections/mqtt/mqtt_client.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 import os
 import time
@@ -34,6 +35,34 @@ def _on_giveup(data: Details) -> None:
     logging.getLogger("mqtt_client").error(
         "Failed to connect to MQTT Broker within set backoff strategy."
     )
+
+
+def _remove_file(path: str) -> None:
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+# paho wants a path, not the certificate itself, so an inline certificate has to
+# be spilled to disk. Cached by content so that constructing several clients does
+# not leave a file behind for each of them, and removed when ISAR exits.
+# The deployments run with a read-only root filesystem and an emptyDir at /tmp,
+# which is where this lands.
+_inline_certificate_paths: dict[str, str] = {}
+
+
+def _write_inline_certificate(certificate: str) -> str:
+    if certificate in _inline_certificate_paths:
+        return _inline_certificate_paths[certificate]
+
+    with NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as certificate_file:
+        certificate_file.write(certificate)
+
+    _inline_certificate_paths[certificate] = certificate_file.name
+    atexit.register(_remove_file, certificate_file.name)
+
+    return certificate_file.name
 
 
 class MqttClient:
@@ -90,11 +119,7 @@ class MqttClient:
             Path to the CA certificate to use.
         """
         if settings.MQTT_CA_CERT:
-            with NamedTemporaryFile(
-                mode="w", suffix=".pem", delete=False
-            ) as certificate_file:
-                certificate_file.write(settings.MQTT_CA_CERT)
-            return certificate_file.name
+            return _write_inline_certificate(settings.MQTT_CA_CERT)
 
         if settings.MQTT_CA_CERT_PATH:
             return settings.MQTT_CA_CERT_PATH

--- a/tests/isar/services/service_connections/test_mqtt_client.py
+++ b/tests/isar/services/service_connections/test_mqtt_client.py
@@ -54,3 +54,17 @@ class TestResolveCaCertificate:
         resolved = Path(client._resolve_ca_certificate(""))
 
         assert resolved.read_text() == CERTIFICATE
+
+    def test_inline_certificate_is_written_once_and_cleaned_up(
+        self, client: MqttClient, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(mqtt_client.settings, "MQTT_CA_CERT", CERTIFICATE)
+        mocker.patch.object(mqtt_client.settings, "MQTT_CA_CERT_PATH", "")
+
+        first = client._resolve_ca_certificate("")
+        second = client._resolve_ca_certificate("")
+
+        assert first == second, "each client must not leave its own certificate behind"
+
+        mqtt_client._remove_file(first)
+        assert not Path(first).exists()

--- a/tests/isar/services/service_connections/test_mqtt_client.py
+++ b/tests/isar/services/service_connections/test_mqtt_client.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from isar.models.mqtt_queue import MQTTQueue
+from isar.services.service_connections.mqtt import mqtt_client
+from isar.services.service_connections.mqtt.mqtt_client import MqttClient
+
+CERTIFICATE = (
+    "-----BEGIN CERTIFICATE-----\nnot-a-real-certificate\n-----END CERTIFICATE-----\n"
+)
+
+
+@pytest.fixture
+def client(mocker: MockerFixture) -> MqttClient:
+    mocker.patch.object(mqtt_client.settings, "MQTT_SSL_ENABLED", False)
+    return MqttClient(mqtt_queue=MQTTQueue())
+
+
+class TestResolveCaCertificate:
+    def test_bundled_certificate_is_used_by_default(
+        self, client: MqttClient, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(mqtt_client.settings, "MQTT_CA_CERT", "")
+        mocker.patch.object(mqtt_client.settings, "MQTT_CA_CERT_PATH", "")
+
+        dirname = str(Path(mqtt_client.__file__).parent)
+        resolved = Path(client._resolve_ca_certificate(dirname)).resolve()
+
+        assert resolved.name == "ca-cert.pem"
+        assert resolved.is_file()
+
+    def test_configured_path_is_used_when_set(
+        self, client: MqttClient, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        certificate_path = tmp_path / "ca.pem"
+        certificate_path.write_text(CERTIFICATE)
+        mocker.patch.object(mqtt_client.settings, "MQTT_CA_CERT", "")
+        mocker.patch.object(
+            mqtt_client.settings, "MQTT_CA_CERT_PATH", str(certificate_path)
+        )
+
+        assert client._resolve_ca_certificate("") == str(certificate_path)
+
+    def test_inline_certificate_takes_precedence_over_path(
+        self, client: MqttClient, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        mocker.patch.object(mqtt_client.settings, "MQTT_CA_CERT", CERTIFICATE)
+        mocker.patch.object(
+            mqtt_client.settings, "MQTT_CA_CERT_PATH", str(tmp_path / "ca.pem")
+        )
+
+        resolved = Path(client._resolve_ca_certificate(""))
+
+        assert resolved.read_text() == CERTIFICATE


### PR DESCRIPTION
## Why

ISAR verified the broker certificate against a CA certificate bundled with the package, at a hardcoded path in `mqtt_client.py`. Every environment therefore had to share one broker certificate, and the armada integration tests had to be handed the production one.

This is the first of three PRs that remove the need for any external secret to run the armada integration tests. See equinor/armada for the other two.

## What

Resolve the CA certificate in this order:

1. `ISAR_MQTT_CA_CERT` — the CA inline as PEM, written to a temporary file on startup.
2. `ISAR_MQTT_CA_CERT_PATH` — a path to a CA certificate file.
3. The certificate bundled with ISAR, as today.

Both new settings default to empty, so behaviour is unchanged unless one is set.

The inline form exists because Kubernetes and testcontainers both deliver this kind of material as an environment variable far more easily than as a mounted file. It is what the integration tests use to hand ISAR a CA minted for that test run.

## Verified

- 3 new unit tests covering all three resolution paths.
- `make check` (mypy) clean, `make format` applied.
- End to end: built into an `isar-robot` image and run through the full armada integration suite against a broker using a generated certificate — 4 passed.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
- [x] Relevant issues are linked
  - No issue exists; this is part of the work to remove external secrets from the integration tests.
- [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.


## Merge order

This is one of five PRs that remove the need for any external secret to run the armada
integration tests. They must merge in this order:

1. equinor/flotilla#2908 — broker takes its credentials at runtime
   equinor/isar#1166 — MQTT CA certificate configurable
   *then wait for the `:dev` images to publish*
1b. equinor/robotics#59 — point the local stack at the generated credentials (needs 1; blocks nothing)
2. equinor/armada#100 — generate MQTT credentials per test run
3. equinor/flotilla#2918, equinor/isar-robot#402, equinor/sara#488 — stop passing the unused secret
4. armada follow-up — drop the now-unused secret declaration, retire the key vault

Out of order it breaks: armada's reusable workflow currently declares
`INTEGRATION_TEST_AZURE_CLIENT_SECRET` as `required: true` and every caller uses `@main`, so a
caller that stops passing it before step 2 fails immediately. Conversely step 2 needs the new
broker and the configurable ISAR CA already published, because it feeds the broker its
credentials through the environment.

