### PR TITLE
Return 400 for malformed inspection definitions

### DIFF
--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -127,17 +127,17 @@ _INSPECTION_SPECS: dict[InspectionTypes, _InspectionSpec] = {
 
 def to_inspection_task(task_definition: StartMissionTaskDefinition) -> TASKS:
     if task_definition.inspection is None:
-        raise ValueError("Inspection in task definition was None")
+        raise MissionFormatError("Inspection in task definition was None")
 
     inspection_definition = task_definition.inspection
     spec = _INSPECTION_SPECS.get(inspection_definition.type)
     if spec is None:
-        raise ValueError(
+        raise MissionFormatError(
             f"Inspection type '{inspection_definition.type}' not supported"
         )
 
     if spec.needs_duration and inspection_definition.duration is None:
-        raise ValueError(
+        raise MissionFormatError(
             f"No duration given to {inspection_definition.type.value} inspection task"
         )
 
@@ -157,7 +157,7 @@ def to_inspection_task(task_definition: StartMissionTaskDefinition) -> TASKS:
     if spec.needs_acoustic_params:
         acoustic = inspection_definition.acoustic
         if acoustic is None:
-            raise ValueError(
+            raise MissionFormatError(
                 f"No acoustic parameters given to "
                 f"{inspection_definition.type.value} inspection task"
             )

--- a/tests/isar/apis/models/test_start_mission_definition.py
+++ b/tests/isar/apis/models/test_start_mission_definition.py
@@ -7,6 +7,7 @@ from alitra import Frame, Orientation, Pose, Position
 from isar.apis.models.models import InputOrientation, InputPose, InputPosition
 from isar.apis.models.start_mission_definition import (
     InspectionTypes,
+    MissionFormatError,
     StartMissionDefinition,
     StartMissionInspectionDefinition,
     StartMissionTaskDefinition,
@@ -165,3 +166,66 @@ def test_acoustic_measurement_forwards_roi_to_task() -> None:
     task = mission.tasks[0]
     assert isinstance(task, TakeAcousticMeasurement)
     assert task.roi == Roi(x=760, y=400, width=133, height=160)
+
+
+def _task_definition_with_inspection(
+    inspection: StartMissionInspectionDefinition | None,
+) -> StartMissionTaskDefinition:
+    return StartMissionTaskDefinition(
+        id="task_id",
+        pose=InputPose(
+            position=InputPosition(x=1, y=1, z=1),
+            orientation=InputOrientation(x=0, y=0, z=0, w=1),
+            frame_name="asset",
+        ),
+        inspection=inspection,
+        tag="tag",
+    )
+
+
+# A malformed mission is the caller's mistake, so it must surface as
+# MissionFormatError, which the scheduling controller answers with 400. A bare
+# ValueError escapes that handler and becomes an opaque 500.
+def test_missing_inspection_is_a_mission_format_error() -> None:
+    mission_definition = StartMissionDefinition(
+        id="mission_id", tasks=[_task_definition_with_inspection(None)]
+    )
+
+    with pytest.raises(MissionFormatError):
+        to_isar_mission(mission_definition)
+
+
+def test_missing_duration_is_a_mission_format_error() -> None:
+    # Video inspections require a duration.
+    mission_definition = StartMissionDefinition(
+        id="mission_id",
+        tasks=[
+            _task_definition_with_inspection(
+                StartMissionInspectionDefinition(
+                    type=InspectionTypes.video,
+                    inspection_target=InputPosition(x=1, y=1, z=1),
+                )
+            )
+        ],
+    )
+
+    with pytest.raises(MissionFormatError):
+        to_isar_mission(mission_definition)
+
+
+def test_missing_acoustic_parameters_is_a_mission_format_error() -> None:
+    mission_definition = StartMissionDefinition(
+        id="mission_id",
+        tasks=[
+            _task_definition_with_inspection(
+                StartMissionInspectionDefinition(
+                    type=InspectionTypes.acoustic_measurement,
+                    inspection_target=InputPosition(x=1, y=1, z=1),
+                    acoustic=None,
+                )
+            )
+        ],
+    )
+
+    with pytest.raises(MissionFormatError):
+        to_isar_mission(mission_definition)


### PR DESCRIPTION
## Why

`POST /schedule/start-mission` answers **500** for a malformed mission definition, where it should answer 400.

`to_inspection_task` raises a bare `ValueError` in four places — a null inspection, an unsupported inspection type, a missing `duration`, and missing acoustic parameters (`src/isar/apis/models/start_mission_definition.py:129-165`). The controller only catches `MissionFormatError`:

```python
except MissionFormatError as e:
    error_message = f"Bad Request - Cannot create ISAR mission: {e}"
    self.logger.warning(error_message)
    raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=error_message)
```
`src/isar/apis/schedule/scheduling_controller.py:59-65`

So the `ValueError` escapes, and only "mission contains no valid tasks" — the one case that already raised `MissionFormatError` — produced the documented 400.

The practical cost is on the caller's side: Flotilla logs a 500 as an ISAR fault and the mission run is set to `Failed` with a generic message, when the real problem is a request it built incorrectly and could report precisely. It also makes a client mistake look like a server fault in the ISAR logs, at `error` rather than `warning`.

## What

Raise `MissionFormatError` instead of `ValueError` in `to_inspection_task`. That is what the surrounding code already uses for exactly this class of problem, and it is what the controller is written to handle. No behaviour changes for well-formed missions.

## Verification

Three tests, one per reachable case — the unsupported-type branch is defensive, since the `InspectionTypes` enum already constrains it. Reverting the source change makes all three fail:

```
FAILED test_missing_inspection_is_a_mission_format_error
FAILED test_missing_duration_is_a_mission_format_error
FAILED test_missing_acoustic_parameters_is_a_mission_format_error
```

Full suite, `black`, `ruff` and `mypy` clean:

```
166 passed in 140.89s
```

Found while extending the armada integration tests (equinor/armada#115).

## Checklist

- [x] Self-review done
- [x] Every commit runs individually (single commit)
- [x] No leftover logging or TODOs
- [x] Tested locally
- [x] Tests written
- [x] No dead code or unused imports
