### PR TITLE
Fix logging next state name

### DIFF
--- a/src/isar/state_machine/state.py
+++ b/src/isar/state_machine/state.py
@@ -87,7 +87,7 @@ class State:
                     )
                     if transition is not None:
                         self.logger.debug(
-                            f"Transitioning from {self.name.name} to {transition.__annotations__['return'].__name__}"
+                            f"Transitioning from {self.name.name} to {transition.__name__}"
                         )
                         return transition
 


### PR DESCRIPTION
States are no longer classes but rather functions. This fixes the debug log.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.