### PR TITLE
Refactor state machine events to request response events

### DIFF
--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -1,6 +1,5 @@
 from collections import deque
 from queue import Empty, Full, Queue, ShutDown
-from threading import Lock
 
 from isar.apis.models.models import (
     ControlMissionResponse,
@@ -89,7 +88,7 @@ class Events:
         )
 
         self.api_requests: APIRequests = APIRequests()
-        self.state_machine_events: StateMachineEvents = StateMachineEvents()
+        self.action_requests: RobotActionRequests = RobotActionRequests()
         self.robot_service_events: RobotServiceEvents = RobotServiceEvents()
 
         self.upload_event: Event[tuple[Inspection, Mission]] = Event(
@@ -111,7 +110,7 @@ class APIEvent[T1, T2]:
 
     def __init__(self, name: str, prioritized: bool = False):
         self.request: Event[T1] = Event("api-" + name + "-request")
-        self.response: Event[T2] = Event("api-" + name + "-request")
+        self.response: Event[T2] = Event("api-" + name + "-response")
         self.prioritized = (
             prioritized  # For when we want to try even if the statemachine is not ready
         )
@@ -149,43 +148,51 @@ class APIRequests:
         )
 
 
-class StateMachineEvents:
+class RobotActionEvent[T1, T2, T3]:
+    """
+    Creates request and response event. The events are defined such that the request is from
+    state machine to robot service, and vice versa for the response. Only one response per
+    request is expected, and other events are cleared before the next one is triggered.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.request: Event[T1] = Event("robot-" + name + "-request")
+        self.success: Event[T2] = Event("robot-" + name + "-success")
+        self.failure: Event[T3] = Event("robot-" + name + "-failure")
+
+    def trigger_request(self, event_value: T1) -> None:
+        self.failure.clear_event()
+        self.success.clear_event()
+        self.request.trigger_event(event_value)
+
+    def trigger_success_response(self, event_value: T2) -> None:
+        self.failure.clear_event()
+        self.success.trigger_event(event_value)
+
+    def trigger_failure_response(self, event_value: T3) -> None:
+        self.success.clear_event()
+        self.failure.trigger_event(event_value)
+
+
+class RobotActionRequests:
     def __init__(self) -> None:
-        self.start_mission: Event[Mission] = Event("start_mission")
-        self.stop_mission: Event[EmptyMessage] = Event("stop_mission")
-        self.pause_mission: Event[EmptyMessage] = Event("pause_mission")
-        self.resume_mission: Event[EmptyMessage] = Event("resume_mission")
+        self.execute_mission: RobotActionEvent[Mission, EmptyMessage, ErrorMessage] = (
+            RobotActionEvent("execute_mission")
+        )
+        self.stop_mission: RobotActionEvent[
+            EmptyMessage, AbortedMission | EmptyMessage, EmptyMessage
+        ] = RobotActionEvent("stop_mission")
+        self.pause_mission: RobotActionEvent[
+            EmptyMessage, EmptyMessage, EmptyMessage
+        ] = RobotActionEvent("pause_mission")
+        self.resume_mission: RobotActionEvent[
+            EmptyMessage, EmptyMessage, EmptyMessage
+        ] = RobotActionEvent("resume_mission")
 
 
 class RobotServiceEvents:
     def __init__(self) -> None:
-        self.mission_succeeded: Event[EmptyMessage] = Event("mission_succeeded")
-        self.mission_failed: Event[ErrorMessage] = Event("mission_failed")
-        self.mission_started_successfully: Event[EmptyMessage] = Event(
-            "mission_started_successfully"
-        )
         self.robot_status_update: Event[RobotStatus] = Event("robot_status_update")
-        self.mission_failed_to_stop: Event[EmptyMessage] = Event(
-            "mission_failed_to_stop"
-        )
-        self.mission_successfully_stopped: Event[AbortedMission] = Event(
-            "mission_successfully_stopped"
-        )
-        self.stopped_mission_already_done: Event[EmptyMessage] = Event(
-            "stopped_mission_already_done"
-        )
-        self.mission_failed_to_pause: Event[EmptyMessage] = Event(
-            "mission_failed_to_pause"
-        )
-        self.mission_successfully_paused: Event[EmptyMessage] = Event(
-            "mission_successfully_paused"
-        )
-        self.mission_failed_to_resume: Event[EmptyMessage] = Event(
-            "mission_failed_to_resume"
-        )
-        self.mission_successfully_resumed: Event[EmptyMessage] = Event(
-            "mission_successfully_resumed"
-        )
         self.request_inspection_upload: Event[tuple[InspectionTask, Mission]] = Event(
             "request_inspection_upload"
         )

--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -115,7 +115,6 @@ class APIEvent[T1, T2]:
         self.prioritized = (
             prioritized  # For when we want to try even if the statemachine is not ready
         )
-        self.lock: Lock = Lock()
 
 
 class APIRequests:

--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -89,7 +89,7 @@ class Events:
 
         self.api_requests: APIRequests = APIRequests()
         self.action_requests: RobotActionRequests = RobotActionRequests()
-        self.robot_service_events: RobotServiceEvents = RobotServiceEvents()
+        self.robot_async_events: RobotAsyncEvents = RobotAsyncEvents()
 
         self.upload_event: Event[tuple[Inspection, Mission]] = Event(
             "uploader", maxsize=10
@@ -190,7 +190,7 @@ class RobotActionRequests:
         ] = RobotActionEvent("resume_mission")
 
 
-class RobotServiceEvents:
+class RobotAsyncEvents:
     def __init__(self) -> None:
         self.robot_status_update: Event[RobotStatus] = Event("robot_status_update")
         self.request_inspection_upload: Event[tuple[InspectionTask, Mission]] = Event(

--- a/src/isar/robot/robot_inspection_service.py
+++ b/src/isar/robot/robot_inspection_service.py
@@ -56,7 +56,7 @@ class RobotInspectionService:
     ) -> None:
         self.logger = logging.getLogger("uploader")
         self.upload_task_event: Event[tuple[InspectionTask, Mission]] = (
-            events.robot_service_events.request_inspection_upload
+            events.robot_async_events.request_inspection_upload
         )
         self.upload_inspection_event: Event[tuple[Inspection, Mission]] = (
             events.upload_event

--- a/src/isar/robot/robot_service.py
+++ b/src/isar/robot/robot_service.py
@@ -7,7 +7,7 @@ from isar.models.events import (
     EmptyMessage,
     Events,
     RobotActionRequests,
-    RobotServiceEvents,
+    RobotAsyncEvents,
 )
 from isar.models.mqtt_queue import MQTTQueue
 from isar.robot.robot_battery import RobotBatteryThread
@@ -33,7 +33,7 @@ class RobotService:
     ) -> None:
         self.logger = logging.getLogger("robot")
         self.action_requests: RobotActionRequests = events.action_requests
-        self.robot_service_events: RobotServiceEvents = events.robot_service_events
+        self.robot_async_events: RobotAsyncEvents = events.robot_async_events
         self.mqtt_queue: MQTTQueue = mqtt_queue
         self.robot: RobotInterface = robot
         self.battery_thread: RobotBatteryThread | None = None
@@ -138,7 +138,7 @@ class RobotService:
             should_report_task_status = not mission._is_return_to_home_mission()
 
             def request_inspection_upload(task: InspectionTask) -> None:
-                self.robot_service_events.request_inspection_upload.trigger_event(
+                self.robot_async_events.request_inspection_upload.trigger_event(
                     (task, mission)
                 )
 
@@ -169,15 +169,15 @@ class RobotService:
         self.status_thread = RobotStatusThread(
             robot=self.robot,
             signal_exit=self.signal_exit,
-            robot_service_events=self.robot_service_events,
+            robot_async_events=self.robot_async_events,
         )
         self.status_thread.start()
 
         self.battery_thread = RobotBatteryThread(
             self.robot,
             self.signal_exit,
-            self.robot_service_events.battery_below_mission_threshold,
-            self.robot_service_events.battery_above_recharge_threshold,
+            self.robot_async_events.battery_below_mission_threshold,
+            self.robot_async_events.battery_above_recharge_threshold,
         )
         self.battery_thread.start()
 

--- a/src/isar/robot/robot_service.py
+++ b/src/isar/robot/robot_service.py
@@ -6,8 +6,8 @@ from isar.models.events import (
     AbortedMission,
     EmptyMessage,
     Events,
+    RobotActionRequests,
     RobotServiceEvents,
-    StateMachineEvents,
 )
 from isar.models.mqtt_queue import MQTTQueue
 from isar.robot.robot_battery import RobotBatteryThread
@@ -32,7 +32,7 @@ class RobotService:
         mqtt_queue: MQTTQueue,
     ) -> None:
         self.logger = logging.getLogger("robot")
-        self.state_machine_events: StateMachineEvents = events.state_machine_events
+        self.action_requests: RobotActionRequests = events.action_requests
         self.robot_service_events: RobotServiceEvents = events.robot_service_events
         self.mqtt_queue: MQTTQueue = mqtt_queue
         self.robot: RobotInterface = robot
@@ -59,7 +59,9 @@ class RobotService:
             and error_message.error_reason == ErrorReason.RobotAlreadyHomeException
         ):
             self.logger.info("Did not start return home, since robot was already home")
-            self.robot_service_events.mission_succeeded.trigger_event(EmptyMessage())
+            self.action_requests.execute_mission.trigger_success_response(
+                EmptyMessage()
+            )
             return False
         elif error_message:
             mission.status = MissionStatus.Failed
@@ -67,12 +69,8 @@ class RobotService:
                 f"Failed to initiate due to: {error_message.error_description}"
             )
             self.logger.warning(f"Failed to start mission. {error_message}")
-            self.robot_service_events.mission_failed.trigger_event(error_message)
+            self.action_requests.execute_mission.trigger_failure_response(error_message)
             return False
-        if not mission._is_return_to_home_mission():
-            self.robot_service_events.mission_started_successfully.trigger_event(
-                EmptyMessage()
-            )
         self.logger.info("Received confirmation that mission has started")
         return True
 
@@ -85,9 +83,7 @@ class RobotService:
 
         if error_message:
             self.logger.warning(f"Failed to stop mission. {error_message}")
-            self.robot_service_events.mission_failed_to_stop.trigger_event(
-                EmptyMessage()
-            )
+            self.action_requests.stop_mission.trigger_failure_response(EmptyMessage())
             return
 
         if monitor_mission_task is not None:
@@ -107,17 +103,12 @@ class RobotService:
                         name=aborted_mission.name,
                         tasks=unfinished_tasks,
                     )
-                    self.robot_service_events.mission_successfully_stopped.trigger_event(
+                    self.action_requests.stop_mission.trigger_success_response(
                         continued_mission
                     )
                     return
-        # This is here in case monitor is cancelled at the exact time it sets these events
-        self.robot_service_events.mission_succeeded.clear_event()
-        self.robot_service_events.mission_failed.clear_event()
 
-        self.robot_service_events.stopped_mission_already_done.trigger_event(
-            EmptyMessage()
-        )
+        self.action_requests.stop_mission.trigger_success_response(EmptyMessage())
 
     def _pause_mission_handler(self) -> None:
         error_message: ErrorMessage | None = robot_pause_mission(
@@ -126,13 +117,9 @@ class RobotService:
 
         if error_message:
             self.logger.warning(f"Failed to pause mission. {error_message}")
-            self.robot_service_events.mission_failed_to_pause.trigger_event(
-                EmptyMessage()
-            )
+            self.action_requests.pause_mission.trigger_failure_response(EmptyMessage())
         else:
-            self.robot_service_events.mission_successfully_paused.trigger_event(
-                EmptyMessage()
-            )
+            self.action_requests.pause_mission.trigger_success_response(EmptyMessage())
 
     def _resume_mission_handler(self) -> None:
         error_message: ErrorMessage | None = robot_resume_mission(
@@ -141,13 +128,9 @@ class RobotService:
 
         if error_message:
             self.logger.warning(f"Failed to resume mission. {error_message}")
-            self.robot_service_events.mission_failed_to_resume.trigger_event(
-                EmptyMessage()
-            )
+            self.action_requests.resume_mission.trigger_failure_response(EmptyMessage())
         else:
-            self.robot_service_events.mission_successfully_resumed.trigger_event(
-                EmptyMessage()
-            )
+            self.action_requests.resume_mission.trigger_success_response(EmptyMessage())
 
     async def _monitor_mission_handler(self, mission: Mission) -> Mission | None:
         remaining_mission: Mission | None = None
@@ -171,9 +154,11 @@ class RobotService:
 
             if error_message is not None:
                 self.logger.warning(f"Error monitoring mission. {error_message}")
-                self.robot_service_events.mission_failed.trigger_event(error_message)
+                self.action_requests.execute_mission.trigger_failure_response(
+                    error_message
+                )
             else:
-                self.robot_service_events.mission_succeeded.trigger_event(
+                self.action_requests.execute_mission.trigger_success_response(
                     EmptyMessage()
                 )
         except asyncio.CancelledError:
@@ -184,7 +169,6 @@ class RobotService:
         self.status_thread = RobotStatusThread(
             robot=self.robot,
             signal_exit=self.signal_exit,
-            state_machine_events=self.state_machine_events,
             robot_service_events=self.robot_service_events,
         )
         self.status_thread.start()
@@ -202,7 +186,7 @@ class RobotService:
 
         while not self.signal_exit.wait(0):
             start_mission_request = (
-                self.state_machine_events.start_mission.consume_event()
+                self.action_requests.execute_mission.request.consume_event()
             )
             if start_mission_request:
                 success = self._start_mission_handler(start_mission_request)
@@ -212,19 +196,19 @@ class RobotService:
                     )
 
             pause_mission_request = (
-                self.state_machine_events.pause_mission.consume_event()
+                self.action_requests.pause_mission.request.consume_event()
             )
             if pause_mission_request:
                 self._pause_mission_handler()
 
             resume_mission_request = (
-                self.state_machine_events.resume_mission.consume_event()
+                self.action_requests.resume_mission.request.consume_event()
             )
             if resume_mission_request:
                 self._resume_mission_handler()
 
             stop_mission_request = (
-                self.state_machine_events.stop_mission.consume_event()
+                self.action_requests.stop_mission.request.consume_event()
             )
             if stop_mission_request:
                 await self._stop_mission_handler(monitor_mission_task)

--- a/src/isar/robot/robot_status.py
+++ b/src/isar/robot/robot_status.py
@@ -3,7 +3,7 @@ import time
 from threading import Event, Thread
 
 from isar.config.settings import settings
-from isar.models.events import RobotServiceEvents, StateMachineEvents
+from isar.models.events import RobotServiceEvents
 from robot_interface.models.exceptions.robot_exceptions import RobotException
 from robot_interface.robot_interface import RobotInterface
 
@@ -14,11 +14,9 @@ class RobotStatusThread(Thread):
         robot: RobotInterface,
         signal_exit: Event,
         robot_service_events: RobotServiceEvents,
-        state_machine_events: StateMachineEvents,
     ):
         self.logger = logging.getLogger("robot")
         self.robot_service_events: RobotServiceEvents = robot_service_events
-        self.state_machine_events: StateMachineEvents = state_machine_events
         self.robot: RobotInterface = robot
         self.signal_exit: Event = signal_exit
         self.robot_status_poll_interval: float = settings.ROBOT_API_STATUS_POLL_INTERVAL

--- a/src/isar/robot/robot_status.py
+++ b/src/isar/robot/robot_status.py
@@ -3,7 +3,7 @@ import time
 from threading import Event, Thread
 
 from isar.config.settings import settings
-from isar.models.events import RobotServiceEvents
+from isar.models.events import RobotAsyncEvents
 from robot_interface.models.exceptions.robot_exceptions import RobotException
 from robot_interface.robot_interface import RobotInterface
 
@@ -13,10 +13,10 @@ class RobotStatusThread(Thread):
         self,
         robot: RobotInterface,
         signal_exit: Event,
-        robot_service_events: RobotServiceEvents,
+        robot_async_events: RobotAsyncEvents,
     ):
         self.logger = logging.getLogger("robot")
-        self.robot_service_events: RobotServiceEvents = robot_service_events
+        self.robot_async_events: RobotAsyncEvents = robot_async_events
         self.robot: RobotInterface = robot
         self.signal_exit: Event = signal_exit
         self.robot_status_poll_interval: float = settings.ROBOT_API_STATUS_POLL_INTERVAL
@@ -42,10 +42,10 @@ class RobotStatusThread(Thread):
                 if (
                     robot_status
                     and robot_status
-                    is not self.robot_service_events.robot_status_update.check()
+                    is not self.robot_async_events.robot_status_update.check()
                 ):
-                    self.robot_service_events.robot_status_update.clear_event()
-                    self.robot_service_events.robot_status_update.trigger_event(
+                    self.robot_async_events.robot_status_update.clear_event()
+                    self.robot_async_events.robot_status_update.trigger_event(
                         robot_status
                     )
             except RobotException as e:

--- a/src/isar/services/utilities/scheduling_utilities.py
+++ b/src/isar/services/utilities/scheduling_utilities.py
@@ -387,9 +387,6 @@ class SchedulingUtilities:
     def _send_command(self, input: T1, api_event: APIEvent[T1, T2]) -> T2:
         self._verify_valid_state(api_event)
 
-        if not api_event.lock.acquire(blocking=False):
-            raise EventConflictError("API event has already been sent")
-
         try:
             if api_event.request.has_event():
                 self.logger.error(
@@ -414,4 +411,3 @@ class SchedulingUtilities:
         finally:
             api_event.request.clear_event()
             api_event.response.clear_event()
-            api_event.lock.release()

--- a/src/isar/state_machine/states/await_next_mission.py
+++ b/src/isar/state_machine/states/await_next_mission.py
@@ -36,7 +36,7 @@ def AwaitNextMission(events: Events) -> State:
             handler=lambda _: GoingToLockdown.transition_and_start_mission_and_report_to_api(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_below_mission_threshold,
+            event=events.robot_async_events.battery_below_mission_threshold,
             handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/going_to_lockdown.py
+++ b/src/isar/state_machine/states/going_to_lockdown.py
@@ -12,17 +12,17 @@ def GoingToLockdown(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[ErrorMessage](
-            event=events.robot_service_events.mission_failed,
+            event=events.action_requests.execute_mission.failure,
             handler=lambda _: InterventionNeeded.transition("Lockdown mission failed"),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_resume,
+            event=events.action_requests.resume_mission.failure,
             handler=lambda _: InterventionNeeded.transition(
                 "Failed to resume return to home mission"
             ),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_succeeded,
+            event=events.action_requests.execute_mission.success,
             handler=lambda _: Lockdown.transition_without_responding_to_api(),
         ),
     ]
@@ -39,11 +39,7 @@ def transition_and_start_mission_and_report_to_api() -> Transition:
             LockdownResponse(lockdown_started=True)
         )
 
-        events.robot_service_events.mission_failed.clear_event()
-        events.robot_service_events.mission_succeeded.clear_event()
-        events.robot_service_events.mission_started_successfully.clear_event()
-
-        events.state_machine_events.start_mission.trigger_event(ReturnHomeMission())
+        events.action_requests.execute_mission.trigger_request(ReturnHomeMission())
         return GoingToLockdown(events)
 
     return _transition

--- a/src/isar/state_machine/states/going_to_lockdown_with_mission.py
+++ b/src/isar/state_machine/states/going_to_lockdown_with_mission.py
@@ -31,15 +31,15 @@ def GoingToLockdownWithMission(events: Events, mission: AbortedMission) -> State
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[ErrorMessage](
-            event=events.robot_service_events.mission_failed,
+            event=events.action_requests.execute_mission.failure,
             handler=_lockdown_mission_failed,
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_resume,
+            event=events.action_requests.resume_mission.failure,
             handler=_lockdown_mission_failed_to_resume,
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_succeeded,
+            event=events.action_requests.execute_mission.success,
             handler=lambda _: LockdownWithMission.transition(mission),
         ),
     ]
@@ -58,11 +58,7 @@ def transition_and_start_mission_and_report_to_api(
             LockdownResponse(lockdown_started=True)
         )
 
-        events.robot_service_events.mission_failed.clear_event()
-        events.robot_service_events.mission_succeeded.clear_event()
-        events.robot_service_events.mission_started_successfully.clear_event()
-
-        events.state_machine_events.start_mission.trigger_event(ReturnHomeMission())
+        events.action_requests.execute_mission.trigger_request(ReturnHomeMission())
         return GoingToLockdownWithMission(events, mission)
 
     return _transition

--- a/src/isar/state_machine/states/going_to_recharging.py
+++ b/src/isar/state_machine/states/going_to_recharging.py
@@ -12,13 +12,13 @@ def GoingToRecharging(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[ErrorMessage](
-            event=events.robot_service_events.mission_failed,
+            event=events.action_requests.execute_mission.failure,
             handler=lambda _: InterventionNeeded.transition(
                 "Return home to recharge failed"
             ),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_succeeded,
+            event=events.action_requests.execute_mission.success,
             handler=lambda _: Recharging.transition(),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -35,11 +35,8 @@ def GoingToRecharging(events: Events) -> State:
 
 def transition_and_start_return_home() -> Transition:
     def _transition(events: Events) -> State:
-        events.robot_service_events.mission_failed.clear_event()
-        events.robot_service_events.mission_succeeded.clear_event()
-        events.robot_service_events.mission_started_successfully.clear_event()
 
-        events.state_machine_events.start_mission.trigger_event(ReturnHomeMission())
+        events.action_requests.execute_mission.trigger_request(ReturnHomeMission())
         return GoingToRecharging(events)
 
     return _transition

--- a/src/isar/state_machine/states/going_to_recharging_with_mission.py
+++ b/src/isar/state_machine/states/going_to_recharging_with_mission.py
@@ -33,11 +33,11 @@ def GoingToRechargingWithMission(events: Events, mission: AbortedMission) -> Sta
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[ErrorMessage](
-            event=events.robot_service_events.mission_failed,
+            event=events.action_requests.execute_mission.failure,
             handler=_mission_failed_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_succeeded,
+            event=events.action_requests.execute_mission.success,
             handler=lambda _: RechargingWithMission.transition(mission),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -62,11 +62,8 @@ def transition_and_start_return_home(
     mission: AbortedMission,
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.robot_service_events.mission_failed.clear_event()
-        events.robot_service_events.mission_succeeded.clear_event()
-        events.robot_service_events.mission_started_successfully.clear_event()
 
-        events.state_machine_events.start_mission.trigger_event(ReturnHomeMission())
+        events.action_requests.execute_mission.trigger_request(ReturnHomeMission())
         return GoingToRechargingWithMission(events, mission=mission)
 
     return _transition

--- a/src/isar/state_machine/states/home.py
+++ b/src/isar/state_machine/states/home.py
@@ -43,7 +43,7 @@ def Home(events: Events) -> State:
             handler=lambda _: StoppingUnknownMission.transition_and_respond_to_API(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_service_events.robot_status_update,
+            event=events.robot_async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](
@@ -51,7 +51,7 @@ def Home(events: Events) -> State:
             handler=lambda _: Lockdown.transition_and_respond_to_api(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_below_mission_threshold,
+            event=events.robot_async_events.battery_below_mission_threshold,
             handler=lambda _: Recharging.transition(),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -69,7 +69,7 @@ def Home(events: Events) -> State:
 def transition() -> Transition:
     def _transition(events: Events) -> State:
         # This clears the current robot status value, so we don't read an outdated value
-        events.robot_service_events.robot_status_update.clear_event()
+        events.robot_async_events.robot_status_update.clear_event()
 
         return Home(events)
 

--- a/src/isar/state_machine/states/intervention_needed.py
+++ b/src/isar/state_machine/states/intervention_needed.py
@@ -39,7 +39,7 @@ def InterventionNeeded(events: Events) -> State:
             handler=lambda _: Maintenance.transition_and_reply_to_API(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_service_events.robot_status_update,
+            event=events.robot_async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
     ]

--- a/src/isar/state_machine/states/lockdown.py
+++ b/src/isar/state_machine/states/lockdown.py
@@ -28,10 +28,7 @@ def Lockdown(events: Events) -> State:
 
 
 def transition_without_responding_to_api() -> Transition:
-    def _transition(events: Events) -> State:
-        return Lockdown(events)
-
-    return _transition
+    return Lockdown
 
 
 def transition_and_respond_to_api() -> Transition:

--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -35,12 +35,6 @@ def Monitor(events: Events, mission_id: str) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_started_successfully,
-            handler=lambda _: events.mqtt_queue.publish_mission_status(
-                mission_id, MissionStatus.InProgress, None
-            ),
-        ),
-        EventHandlerMapping[EmptyMessage](
             event=events.api_requests.stop_mission.request,
             handler=lambda _: Stopping.transition_and_trigger_stop_and_respond_to_API(
                 mission_id
@@ -53,11 +47,11 @@ def Monitor(events: Events, mission_id: str) -> State:
             ),
         ),
         EventHandlerMapping[ErrorMessage](
-            event=events.robot_service_events.mission_failed,
+            event=events.action_requests.execute_mission.failure,
             handler=_mission_failed_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_succeeded,
+            event=events.action_requests.execute_mission.success,
             handler=_mission_success_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](
@@ -88,14 +82,11 @@ def transition_and_start_mission(
     mission: Mission, should_respond_to_API_request: bool = False
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.mqtt_queue.publish_mission_status(
-            mission.id, MissionStatus.NotStarted, None
-        )
-        events.robot_service_events.mission_failed.clear_event()
-        events.robot_service_events.mission_succeeded.clear_event()
-        events.robot_service_events.mission_started_successfully.clear_event()
 
-        events.state_machine_events.start_mission.trigger_event(mission)
+        events.action_requests.execute_mission.trigger_request(mission)
+        events.mqtt_queue.publish_mission_status(
+            mission.id, MissionStatus.InProgress, None
+        )
 
         if should_respond_to_API_request:
             events.api_requests.start_mission.response.trigger_event(

--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -55,7 +55,7 @@ def Monitor(events: Events, mission_id: str) -> State:
             handler=_mission_success_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_below_mission_threshold,
+            event=events.robot_async_events.battery_below_mission_threshold,
             handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/offline.py
+++ b/src/isar/state_machine/states/offline.py
@@ -27,7 +27,7 @@ def Offline(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[RobotStatus](
-            event=events.robot_service_events.robot_status_update,
+            event=events.robot_async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/paused.py
+++ b/src/isar/state_machine/states/paused.py
@@ -24,7 +24,7 @@ def Paused(events: Events, mission_id: str) -> State:
             ),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_below_mission_threshold,
+            event=events.robot_async_events.battery_below_mission_threshold,
             handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/pausing.py
+++ b/src/isar/state_machine/states/pausing.py
@@ -17,11 +17,11 @@ def Pausing(events: Events, mission_id: str) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_pause,
+            event=events.action_requests.pause_mission.failure,
             handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_successfully_paused,
+            event=events.action_requests.pause_mission.success,
             handler=_successful_pause_event_handler,
         ),
     ]
@@ -39,7 +39,7 @@ def transition_and_pause_mission_and_reply_to_API(
         events.api_requests.pause_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )
-        events.state_machine_events.pause_mission.trigger_event(EmptyMessage())
+        events.action_requests.pause_mission.trigger_request(EmptyMessage())
         return Pausing(events, mission_id=mission_id)
 
     return _transition

--- a/src/isar/state_machine/states/pausing_return_home.py
+++ b/src/isar/state_machine/states/pausing_return_home.py
@@ -10,11 +10,11 @@ def PausingReturnHome(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_pause,
+            event=events.action_requests.pause_mission.failure,
             handler=lambda _: ReturningHome.transition_to_existing_mission(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_successfully_paused,
+            event=events.action_requests.pause_mission.success,
             handler=lambda _: ReturnHomePaused.transition(),
         ),
     ]
@@ -30,7 +30,7 @@ def transition_and_pause_mission_and_reply_to_API() -> Transition:
         events.api_requests.pause_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )
-        events.state_machine_events.pause_mission.trigger_event(EmptyMessage())
+        events.action_requests.pause_mission.trigger_request(EmptyMessage())
         return PausingReturnHome(events)
 
     return _transition

--- a/src/isar/state_machine/states/recharging.py
+++ b/src/isar/state_machine/states/recharging.py
@@ -12,11 +12,11 @@ def Recharging(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_above_recharge_threshold,
+            event=events.robot_async_events.battery_above_recharge_threshold,
             handler=lambda _: Home.transition(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_service_events.robot_status_update,
+            event=events.robot_async_events.robot_status_update,
             handler=lambda robot_status: (
                 Offline.transition() if robot_status == RobotStatus.Offline else None
             ),

--- a/src/isar/state_machine/states/recharging_with_mission.py
+++ b/src/isar/state_machine/states/recharging_with_mission.py
@@ -22,13 +22,13 @@ def RechargingWithMission(events: Events, mission: AbortedMission) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_above_recharge_threshold,
+            event=events.robot_async_events.battery_above_recharge_threshold,
             handler=lambda _: Monitor.transition_and_start_mission(
                 mission, should_respond_to_API_request=False
             ),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_service_events.robot_status_update,
+            event=events.robot_async_events.robot_status_update,
             handler=lambda robot_status: (
                 Offline.transition() if robot_status == RobotStatus.Offline else None
             ),

--- a/src/isar/state_machine/states/resuming.py
+++ b/src/isar/state_machine/states/resuming.py
@@ -19,11 +19,11 @@ def Resuming(events: Events, mission_id: str) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_resume,
+            event=events.action_requests.resume_mission.failure,
             handler=lambda _: Paused.transition(mission_id),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_successfully_resumed,
+            event=events.action_requests.resume_mission.success,
             handler=_successful_resume_event_handler,
         ),
     ]
@@ -41,7 +41,7 @@ def transition_resume_mission_and_respond_to_API(
         events.api_requests.resume_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )
-        events.state_machine_events.resume_mission.trigger_event(EmptyMessage())
+        events.action_requests.resume_mission.trigger_request(EmptyMessage())
         return Resuming(events, mission_id)
 
     return _transition

--- a/src/isar/state_machine/states/resuming_return_home.py
+++ b/src/isar/state_machine/states/resuming_return_home.py
@@ -10,11 +10,11 @@ def ResumingReturnHome(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_resume,
+            event=events.action_requests.resume_mission.failure,
             handler=lambda _: ReturnHomePaused.transition(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_successfully_resumed,
+            event=events.action_requests.resume_mission.success,
             handler=lambda _: ReturningHome.transition_to_existing_mission(),
         ),
     ]
@@ -30,7 +30,7 @@ def transition_and_resume_mission_and_reply_to_API() -> Transition:
         events.api_requests.resume_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )
-        events.state_machine_events.resume_mission.trigger_event(EmptyMessage())
+        events.action_requests.resume_mission.trigger_request(EmptyMessage())
         return ResumingReturnHome(events)
 
     return _transition

--- a/src/isar/state_machine/states/return_home_paused.py
+++ b/src/isar/state_machine/states/return_home_paused.py
@@ -24,7 +24,7 @@ def ReturnHomePaused(events: Events) -> State:
             handler=lambda _: ResumingReturnHome.transition_and_resume_mission_and_reply_to_API(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_below_mission_threshold,
+            event=events.robot_async_events.battery_below_mission_threshold,
             handler=lambda _: ReturningHome.transition_to_existing_mission(),
         ),
         EventHandlerMapping[Mission](

--- a/src/isar/state_machine/states/return_home_paused.py
+++ b/src/isar/state_machine/states/return_home_paused.py
@@ -14,7 +14,7 @@ def ReturnHomePaused(events: Events) -> State:
     def _send_to_lockdown_event_handler(
         _: EmptyMessage,
     ) -> Transition:
-        events.state_machine_events.resume_mission.trigger_event(EmptyMessage())
+        events.action_requests.resume_mission.trigger_request(EmptyMessage())
 
         return GoingToLockdown.transition_to_existing_mission_and_report_to_api()
 

--- a/src/isar/state_machine/states/returning_home.py
+++ b/src/isar/state_machine/states/returning_home.py
@@ -34,7 +34,7 @@ def ReturningHome(
             handler=lambda _: PausingReturnHome.transition_and_pause_mission_and_reply_to_API(),
         ),
         EventHandlerMapping[ErrorMessage](
-            event=events.robot_service_events.mission_failed,
+            event=events.action_requests.execute_mission.failure,
             handler=_mission_failed_event_handler,
         ),
         EventHandlerMapping[Mission](
@@ -44,7 +44,7 @@ def ReturningHome(
             ),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_succeeded,
+            event=events.action_requests.execute_mission.success,
             handler=lambda _: Home.transition(),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -72,11 +72,8 @@ def transition_and_start_mission(
     retries: int = settings.RETURN_HOME_RETRY_LIMIT - 1,
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.robot_service_events.mission_failed.clear_event()
-        events.robot_service_events.mission_succeeded.clear_event()
-        events.robot_service_events.mission_started_successfully.clear_event()
 
-        events.state_machine_events.start_mission.trigger_event(ReturnHomeMission())
+        events.action_requests.execute_mission.trigger_request(ReturnHomeMission())
 
         if should_respond_to_API_request:
             events.api_requests.return_home.response.trigger_event(EmptyMessage())

--- a/src/isar/state_machine/states/returning_home.py
+++ b/src/isar/state_machine/states/returning_home.py
@@ -48,7 +48,7 @@ def ReturningHome(
             handler=lambda _: Home.transition(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.battery_below_mission_threshold,
+            event=events.robot_async_events.battery_below_mission_threshold,
             handler=lambda _: GoingToRecharging.transition_to_existing_mission(),
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/stopping.py
+++ b/src/isar/state_machine/states/stopping.py
@@ -22,15 +22,11 @@ def Stopping(events: Events, mission_id: str) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=lambda _: Monitor.transition_with_existing_mission(mission_id),
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=_successful_stop_event_handler,
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
             handler=_successful_stop_event_handler,
         ),
     ]
@@ -45,7 +41,7 @@ def transition_and_trigger_stop_and_respond_to_API(
     mission_id: str,
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         events.api_requests.stop_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )

--- a/src/isar/state_machine/states/stopping_due_to_maintenance.py
+++ b/src/isar/state_machine/states/stopping_due_to_maintenance.py
@@ -33,15 +33,11 @@ def StoppingDueToMaintenance(events: Events, mission_id: str | None = None) -> S
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=_failed_stop_event_handler,
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=_successful_stop_event_handler,
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
             handler=_successful_stop_event_handler,
         ),
     ]
@@ -56,7 +52,7 @@ def transition_and_stop_mission(
     mission_id: str | None = None,
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         return StoppingDueToMaintenance(events, mission_id)
 
     return _transition

--- a/src/isar/state_machine/states/stopping_go_to_lockdown.py
+++ b/src/isar/state_machine/states/stopping_go_to_lockdown.py
@@ -32,15 +32,11 @@ def StoppingGoToLockdown(events: Events, mission_id: str) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=_failed_stop_event_handler,
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=_successful_stop_event_handler,
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
             handler=_successful_stop_event_handler,
         ),
     ]
@@ -53,7 +49,7 @@ def StoppingGoToLockdown(events: Events, mission_id: str) -> State:
 
 def transition_and_stop_mission(mission_id: str) -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         return StoppingGoToLockdown(events, mission_id)
 
     return _transition

--- a/src/isar/state_machine/states/stopping_go_to_recharge.py
+++ b/src/isar/state_machine/states/stopping_go_to_recharge.py
@@ -8,22 +8,26 @@ from isar.state_machine.states_enum import States
 
 def StoppingGoToRecharge(events: Events) -> State:
 
+    def _mission_stopped_event_handler(
+        aborted_mission: AbortedMission | EmptyMessage,
+    ) -> Transition:
+        if isinstance(aborted_mission, AbortedMission):
+            return GoingToRechargingWithMission.transition_and_start_return_home(
+                aborted_mission
+            )
+        else:
+            return GoingToRecharging.transition_and_start_return_home()
+
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=lambda _: InterventionNeeded.transition(
                 "Failed to stop mission when battery was low"
             ),
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=lambda aborted_mission: GoingToRechargingWithMission.transition_and_start_return_home(
-                aborted_mission
-            ),
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
-            handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
+            handler=_mission_stopped_event_handler,
         ),
     ]
     return State(
@@ -35,7 +39,7 @@ def StoppingGoToRecharge(events: Events) -> State:
 
 def transition_and_stop_mission() -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         return StoppingGoToRecharge(events)
 
     return _transition

--- a/src/isar/state_machine/states/stopping_paused_mission.py
+++ b/src/isar/state_machine/states/stopping_paused_mission.py
@@ -19,15 +19,11 @@ def StoppingPausedMission(events: Events, mission_id: str) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=lambda _: Paused.transition(mission_id),
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=_successful_stop_event_handler,
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
             handler=_successful_stop_event_handler,
         ),
     ]
@@ -42,7 +38,7 @@ def transition_and_trigger_stop(
     mission_id: str, should_respond_to_API_request: bool = False
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         if should_respond_to_API_request:
             events.api_requests.stop_mission.response.trigger_event(
                 ControlMissionResponse(success=True)

--- a/src/isar/state_machine/states/stopping_paused_return_home.py
+++ b/src/isar/state_machine/states/stopping_paused_return_home.py
@@ -11,17 +11,13 @@ def StoppingPausedReturnHome(events: Events, mission: Mission) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=lambda _: InterventionNeeded.transition(
                 "Failed to stop paused return home mission"
             ),
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=lambda _: Monitor.transition_and_start_mission(mission, True),
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
             handler=lambda _: Monitor.transition_and_start_mission(mission, True),
         ),
     ]
@@ -36,7 +32,7 @@ def transition_and_stop_return_home_and_reply_to_API(
     mission: Mission,
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
 
         response = MissionStartResponse(
             mission_id=mission.id,

--- a/src/isar/state_machine/states/stopping_return_home.py
+++ b/src/isar/state_machine/states/stopping_return_home.py
@@ -11,15 +11,11 @@ def StoppingReturnHome(events: Events, mission: Mission) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=lambda _: ReturningHome.transition_to_existing_mission(),
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=lambda _: Monitor.transition_and_start_mission(mission, True),
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
             handler=lambda _: Monitor.transition_and_start_mission(mission, True),
         ),
     ]
@@ -34,7 +30,7 @@ def transition_and_stop_return_home_and_reply_to_API(
     mission: Mission,
 ) -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         response = MissionStartResponse(
             mission_id=mission.id,
             mission_started=True,

--- a/src/isar/state_machine/states/stopping_unknown_mission.py
+++ b/src/isar/state_machine/states/stopping_unknown_mission.py
@@ -10,17 +10,13 @@ def StoppingUnknownMission(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.mission_failed_to_stop,
+            event=events.action_requests.stop_mission.failure,
             handler=lambda _: InterventionNeeded.transition(
                 "Failed to stop unknown mission"
             ),
         ),
-        EventHandlerMapping[AbortedMission](
-            event=events.robot_service_events.mission_successfully_stopped,
-            handler=lambda _: AwaitNextMission.transition(),
-        ),
-        EventHandlerMapping[EmptyMessage](
-            event=events.robot_service_events.stopped_mission_already_done,
+        EventHandlerMapping[AbortedMission | EmptyMessage](
+            event=events.action_requests.stop_mission.success,
             handler=lambda _: AwaitNextMission.transition(),
         ),
     ]
@@ -33,7 +29,7 @@ def StoppingUnknownMission(events: Events) -> State:
 
 def transition() -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         return StoppingUnknownMission(events)
 
     return _transition
@@ -41,7 +37,7 @@ def transition() -> Transition:
 
 def transition_and_respond_to_API() -> Transition:
     def _transition(events: Events) -> State:
-        events.state_machine_events.stop_mission.trigger_event(EmptyMessage())
+        events.action_requests.stop_mission.trigger_request(EmptyMessage())
         events.api_requests.stop_mission.response.trigger_event(
             ControlMissionResponse(success=True)
         )

--- a/src/isar/state_machine/states/unknown_status.py
+++ b/src/isar/state_machine/states/unknown_status.py
@@ -32,7 +32,7 @@ def UnknownStatus(events: Events) -> State:
             handler=lambda _: StoppingUnknownMission.transition_and_respond_to_API(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_service_events.robot_status_update,
+            event=events.robot_async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](

--- a/tests/isar/services/robot/test_robot_service.py
+++ b/tests/isar/services/robot/test_robot_service.py
@@ -2,6 +2,7 @@ import asyncio
 
 from pytest_mock import MockerFixture
 
+from isar.models.events import EmptyMessage
 from isar.robot.robot_service import RobotService
 from robot_interface.models.exceptions.robot_exceptions import (
     ErrorMessage,
@@ -34,8 +35,8 @@ def test_mission_fails_to_schedule(
 
     r_service._start_mission_handler(mission)
 
-    assert r_service.robot_service_events.mission_failed.has_event()
-    mission_failed_event = r_service.robot_service_events.mission_failed.get()
+    assert r_service.action_requests.execute_mission.failure.has_event()
+    mission_failed_event = r_service.action_requests.execute_mission.failure.get()
     assert mission_failed_event is not None
     assert mission_failed_event.error_reason == ErrorReason.RobotUnknownErrorException
 
@@ -72,12 +73,10 @@ def test_mission_fails_to_stop(
 
     asyncio.run(r_service._stop_mission_handler(None))
 
-    assert r_service.robot_service_events.mission_failed_to_stop.has_event()
-    mission_failed_to_stop_event = (
-        r_service.robot_service_events.mission_failed_to_stop.get()
-    )
+    assert r_service.action_requests.stop_mission.failure.has_event()
+    mission_failed_to_stop_event = r_service.action_requests.stop_mission.failure.get()
     assert mission_failed_to_stop_event is not None
-    assert not r_service.robot_service_events.mission_successfully_stopped.has_event()
+    assert not r_service.action_requests.stop_mission.success.has_event()
 
 
 def test_successful_stop_with_remaining_tasks(
@@ -109,10 +108,10 @@ def test_successful_stop_with_remaining_tasks(
 
     asyncio.run(test_stop_mission_handler())
 
-    assert r_service.robot_service_events.mission_successfully_stopped.has_event()
-    assert not r_service.robot_service_events.mission_failed_to_stop.has_event()
-    assert not r_service.robot_service_events.mission_failed.has_event()
-    assert not r_service.robot_service_events.mission_succeeded.has_event()
+    assert r_service.action_requests.stop_mission.success.has_event()
+    assert not r_service.action_requests.stop_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.success.has_event()
 
 
 def test_successful_stop_with_no_remaining_tasks(
@@ -144,10 +143,13 @@ def test_successful_stop_with_no_remaining_tasks(
 
     asyncio.run(test_stop_mission_handler())
 
-    assert r_service.robot_service_events.stopped_mission_already_done.has_event()
-    assert not r_service.robot_service_events.mission_failed_to_stop.has_event()
-    assert not r_service.robot_service_events.mission_failed.has_event()
-    assert not r_service.robot_service_events.mission_succeeded.has_event()
+    assert r_service.action_requests.stop_mission.success.has_event()
+    assert isinstance(
+        r_service.action_requests.stop_mission.success.get(), EmptyMessage
+    )
+    assert not r_service.action_requests.stop_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.success.has_event()
 
 
 def test_successful_stop_with_no_ongoing_monitoring(
@@ -159,10 +161,13 @@ def test_successful_stop_with_no_ongoing_monitoring(
 
     asyncio.run(r_service._stop_mission_handler(None))
 
-    assert r_service.robot_service_events.stopped_mission_already_done.has_event()
-    assert not r_service.robot_service_events.mission_failed_to_stop.has_event()
-    assert not r_service.robot_service_events.mission_failed.has_event()
-    assert not r_service.robot_service_events.mission_succeeded.has_event()
+    assert r_service.action_requests.stop_mission.success.has_event()
+    assert isinstance(
+        r_service.action_requests.stop_mission.success.get(), EmptyMessage
+    )
+    assert not r_service.action_requests.stop_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.success.has_event()
 
 
 def test_monitor_mission_reports_nothing_after_mission_stopped(
@@ -182,8 +187,8 @@ def test_monitor_mission_reports_nothing_after_mission_stopped(
 
     asyncio.run(r_service._monitor_mission_handler(mission))
 
-    assert not r_service.robot_service_events.mission_failed.has_event()
-    assert not r_service.robot_service_events.mission_succeeded.has_event()
+    assert not r_service.action_requests.execute_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.success.has_event()
 
 
 def test_monitor_mission_reports_mission_failed(
@@ -207,8 +212,8 @@ def test_monitor_mission_reports_mission_failed(
 
     asyncio.run(r_service._monitor_mission_handler(mission))
 
-    assert r_service.robot_service_events.mission_failed.has_event()
-    assert not r_service.robot_service_events.mission_succeeded.has_event()
+    assert r_service.action_requests.execute_mission.failure.has_event()
+    assert not r_service.action_requests.execute_mission.success.has_event()
 
 
 def test_monitor_mission_reports_mission_success(
@@ -228,8 +233,8 @@ def test_monitor_mission_reports_mission_success(
 
     asyncio.run(r_service._monitor_mission_handler(mission))
 
-    assert r_service.robot_service_events.mission_succeeded.has_event()
-    assert not r_service.robot_service_events.mission_failed.has_event()
+    assert r_service.action_requests.execute_mission.success.has_event()
+    assert not r_service.action_requests.execute_mission.failure.has_event()
 
 
 def test_mission_fails_to_pause(
@@ -247,12 +252,12 @@ def test_mission_fails_to_pause(
 
     r_service._pause_mission_handler()
 
-    assert r_service.robot_service_events.mission_failed_to_pause.has_event()
+    assert r_service.action_requests.pause_mission.failure.has_event()
     mission_failed_to_pause_event = (
-        r_service.robot_service_events.mission_failed_to_pause.get()
+        r_service.action_requests.pause_mission.failure.get()
     )
     assert mission_failed_to_pause_event is not None
-    assert not r_service.robot_service_events.mission_successfully_paused.has_event()
+    assert not r_service.action_requests.pause_mission.success.has_event()
 
 
 def test_mission_succeeds_to_pause(
@@ -264,8 +269,8 @@ def test_mission_succeeds_to_pause(
 
     r_service._pause_mission_handler()
 
-    assert not r_service.robot_service_events.mission_failed_to_pause.has_event()
-    assert r_service.robot_service_events.mission_successfully_paused.has_event()
+    assert not r_service.action_requests.pause_mission.failure.has_event()
+    assert r_service.action_requests.pause_mission.success.has_event()
 
 
 def test_mission_fails_to_resume(
@@ -283,12 +288,12 @@ def test_mission_fails_to_resume(
 
     r_service._resume_mission_handler()
 
-    assert r_service.robot_service_events.mission_failed_to_resume.has_event()
+    assert r_service.action_requests.resume_mission.failure.has_event()
     mission_failed_to_resume_event = (
-        r_service.robot_service_events.mission_failed_to_resume.get()
+        r_service.action_requests.resume_mission.failure.get()
     )
     assert mission_failed_to_resume_event is not None
-    assert not r_service.robot_service_events.mission_successfully_resumed.has_event()
+    assert not r_service.action_requests.resume_mission.success.has_event()
 
 
 def test_mission_succeeds_to_resume(
@@ -300,8 +305,8 @@ def test_mission_succeeds_to_resume(
 
     r_service._resume_mission_handler()
 
-    assert not r_service.robot_service_events.mission_failed_to_resume.has_event()
-    assert r_service.robot_service_events.mission_successfully_resumed.has_event()
+    assert not r_service.action_requests.resume_mission.failure.has_event()
+    assert r_service.action_requests.resume_mission.success.has_event()
 
 
 def test_start_mission_reports_robot_already_home(
@@ -321,4 +326,4 @@ def test_start_mission_reports_robot_already_home(
     success = r_service._start_mission_handler(mission)
 
     assert not success
-    assert r_service.robot_service_events.mission_succeeded.has_event()
+    assert r_service.action_requests.execute_mission.success.has_event()

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -93,7 +93,7 @@ def test_unknown_status_transitions_to_await_next_mission_if_it_was_already_avai
     current_state = UnknownStatus(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.robot_status_update
+        events.robot_async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Available)

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -74,7 +74,7 @@ def test_transition_from_resuming_to_paused(events: Events) -> None:
     current_state = Resuming(events, "mission_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_resume
+        events.action_requests.resume_mission.failure
     )
 
     transition = event_handler.handler(
@@ -108,7 +108,7 @@ def test_transition_from_resuming_return_home_to_await_next_mission(
     current_state = ResumingReturnHome(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_resume
+        events.action_requests.resume_mission.failure
     )
 
     transition = event_handler.handler(

--- a/tests/isar/state_machine/states/test_going_to_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_going_to_lockdown_state.py
@@ -30,7 +30,7 @@ def test_transition_from_return_home_paused_to_going_to_lockdown(
 
     lockdown_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.mission_failed_to_resume
+            events.action_requests.resume_mission.failure
         )
     )
 
@@ -49,7 +49,7 @@ def test_stopping_lockdown_transitions_to_going_to_lockdown(events: Events) -> N
     current_state = StoppingGoToLockdown(events, "mission_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_stopped
+        events.action_requests.stop_mission.success
     )
 
     aborted_mission: Mission = Mission(

--- a/tests/isar/state_machine/states/test_going_to_recharging_state.py
+++ b/tests/isar/state_machine/states/test_going_to_recharging_state.py
@@ -13,7 +13,7 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_when_no_remaining_task
 ) -> None:
     current_state = StoppingGoToRecharge(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.stopped_mission_already_done
+        events.action_requests.stop_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -27,7 +27,7 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
 ) -> None:
     current_state = StoppingGoToRecharge(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_stopped
+        events.action_requests.stop_mission.success
     )
 
     transition = event_handler.handler(AbortedMission(id="id", name="test"))

--- a/tests/isar/state_machine/states/test_going_to_recharging_state.py
+++ b/tests/isar/state_machine/states/test_going_to_recharging_state.py
@@ -41,7 +41,7 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
 def test_return_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = ReturningHome(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_below_mission_threshold
+        events.robot_async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_home_state.py
+++ b/tests/isar/state_machine/states/test_home_state.py
@@ -61,7 +61,7 @@ def test_intervention_needed_transitions_to_home_if_robot_is_home(
     current_state = InterventionNeeded(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.robot_status_update
+        events.robot_async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Home)
@@ -76,7 +76,7 @@ def test_recharging_goes_to_home_when_battery_high(events: Events) -> None:
     current_state = Recharging(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_above_recharge_threshold
+        events.robot_async_events.battery_above_recharge_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_home_state.py
+++ b/tests/isar/state_machine/states/test_home_state.py
@@ -30,12 +30,12 @@ def test_state_machine_with_return_home_failure_successful_retries(
 
     event_handler_success: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.mission_succeeded
+            events.action_requests.execute_mission.success
         )
     )
     event_handler_failure: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.mission_failed
+            events.action_requests.execute_mission.failure
         )
     )
 

--- a/tests/isar/state_machine/states/test_intervention_needed_state.py
+++ b/tests/isar/state_machine/states/test_intervention_needed_state.py
@@ -13,7 +13,7 @@ from robot_interface.models.mission.status import RobotStatus
 def test_going_to_recharging_goes_to_intervention_needed(events: Events) -> None:
     current_state = GoingToRecharging(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed
+        events.action_requests.execute_mission.failure
     )
 
     transition = event_handler.handler(
@@ -33,7 +33,7 @@ def test_going_to_lockdown_task_failed_transitions_to_intervention_needed(
     current_state = GoingToLockdown(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed
+        events.action_requests.execute_mission.failure
     )
 
     transition = event_handler.handler(
@@ -53,7 +53,7 @@ def test_going_to_lockdown_mission_failed_transitions_to_intervention_needed(
     current_state = GoingToLockdown(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed
+        events.action_requests.execute_mission.failure
     )
 
     # The type of error reason is not important for this test
@@ -73,7 +73,7 @@ def test_state_machine_with_return_home_failure(events: Events) -> None:
     for i in range(settings.RETURN_HOME_RETRY_LIMIT - 1):
 
         failure_event_handler = current_state.get_event_handler_by_event(
-            events.robot_service_events.mission_failed
+            events.action_requests.execute_mission.failure
         )
 
         transition = failure_event_handler.handler(
@@ -88,7 +88,7 @@ def test_state_machine_with_return_home_failure(events: Events) -> None:
         assert current_state.name is States.ReturningHome
 
     failure_event_handler = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed
+        events.action_requests.execute_mission.failure
     )
 
     transition = failure_event_handler.handler(

--- a/tests/isar/state_machine/states/test_intervention_needed_state.py
+++ b/tests/isar/state_machine/states/test_intervention_needed_state.py
@@ -108,7 +108,7 @@ def test_intervention_needed_transitions_does_not_transition_if_status_is_not_ho
     current_state = InterventionNeeded(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.robot_status_update
+        events.robot_async_events.robot_status_update
     )
 
     statuses = [

--- a/tests/isar/state_machine/states/test_lockdown_state.py
+++ b/tests/isar/state_machine/states/test_lockdown_state.py
@@ -22,7 +22,7 @@ def test_going_to_lockdown_transitions_to_lockdown(events: Events) -> None:
     current_state = GoingToLockdown(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_succeeded
+        events.action_requests.execute_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_maintenance_mode_state.py
+++ b/tests/isar/state_machine/states/test_maintenance_mode_state.py
@@ -13,7 +13,7 @@ def test_home_transitions_to_maintenance_mode_when_teleoperating(
     current_state = Home(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.robot_status_update
+        events.robot_async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
@@ -30,7 +30,7 @@ def test_unknown_status_transitions_to_maintenance_mode_when_teleoperating(
     current_state = UnknownStatus(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.robot_status_update
+        events.robot_async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
@@ -47,7 +47,7 @@ def test_offline_transitions_to_maintenance_mode_when_teleoperating(
     current_state = Offline(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.robot_status_update
+        events.robot_async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -203,7 +203,7 @@ def test_transition_from_monitor_to_stopping_to_recharge(events: Events) -> None
     current_state = Monitor(events, "test_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_below_mission_threshold
+        events.robot_async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -42,7 +42,7 @@ def _mock_robot_exception_with_message() -> RobotException:
 def test_stopping_to_recharge_goes_to_intervention_needed(events: Events) -> None:
     current_state = StoppingGoToRecharge(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_stop
+        events.action_requests.stop_mission.failure
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -60,7 +60,7 @@ def test_transitioning_to_monitor_from_stopping_when_return_home_cancelled(
     current_state = StoppingReturnHome(events, example_mission)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_stopped
+        events.action_requests.stop_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -73,7 +73,7 @@ def test_stopping_lockdown_failing_to_monitor(events: Events) -> None:
     current_state = StoppingGoToLockdown(events, "mission_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_stop
+        events.action_requests.stop_mission.failure
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -90,7 +90,7 @@ def test_transition_from_pausing_to_monitor(events: Events) -> None:
     current_state = Pausing(events, "mission_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_pause
+        events.action_requests.pause_mission.failure
     )
 
     error_event = ErrorMessage(
@@ -106,7 +106,7 @@ def test_transition_from_resuming_to_monitor(events: Events) -> None:
     current_state = Resuming(events, "mission_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_resumed
+        events.action_requests.resume_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -212,4 +212,4 @@ def test_transition_from_monitor_to_stopping_to_recharge(events: Events) -> None
 
     assert current_state.name is States.StoppingGoToRecharge
     assert not events.api_requests.stop_mission.response.has_event()
-    assert events.state_machine_events.stop_mission.has_event()
+    assert events.action_requests.stop_mission.request.has_event()

--- a/tests/isar/state_machine/states/test_paused_state.py
+++ b/tests/isar/state_machine/states/test_paused_state.py
@@ -37,7 +37,7 @@ def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_below_mission_threshold
+        events.robot_async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_paused_state.py
+++ b/tests/isar/state_machine/states/test_paused_state.py
@@ -9,7 +9,7 @@ def test_transition_from_pausing_to_paused(events: Events) -> None:
     current_state = Pausing(events, "mission_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_paused
+        events.action_requests.pause_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -46,4 +46,4 @@ def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
 
     assert current_state.name is States.StoppingGoToRecharge
     assert not events.api_requests.stop_mission.response.has_event()
-    assert events.state_machine_events.stop_mission.has_event()
+    assert events.action_requests.stop_mission.request.has_event()

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -21,7 +21,7 @@ def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
 def test_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = Home(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_below_mission_threshold
+        events.robot_async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -35,7 +35,7 @@ def test_continuing_mission_when_battery_high(events: Events) -> None:
         events, mission=AbortedMission(name="test", id="test_id")
     )
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_above_recharge_threshold
+        events.robot_async_events.battery_above_recharge_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -9,7 +9,7 @@ from isar.state_machine.states_enum import States
 def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
     current_state = GoingToRecharging(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_succeeded
+        events.action_requests.execute_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_return_home_paused_state.py
+++ b/tests/isar/state_machine/states/test_return_home_paused_state.py
@@ -12,7 +12,7 @@ def test_transition_from_pausing_return_home_to_return_home_paused(
     current_state = PausingReturnHome(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_paused
+        events.action_requests.pause_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_returning_home_state.py
+++ b/tests/isar/state_machine/states/test_returning_home_state.py
@@ -17,7 +17,7 @@ def test_transitioning_to_returning_home_from_stopping_when_return_home_failed(
     current_state = StoppingReturnHome(events, example_mission)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_stopped
+        events.action_requests.stop_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -30,7 +30,7 @@ def test_transition_from_pausing_return_home_to_returning_home(events: Events) -
     current_state = PausingReturnHome(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_pause
+        events.action_requests.pause_mission.failure
     )
 
     error_event = ErrorMessage(
@@ -48,7 +48,7 @@ def test_transition_from_resuming_return_home_to_returning_home_state(
     current_state = ResumingReturnHome(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_resumed
+        events.action_requests.resume_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -63,7 +63,7 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
     current_state: State = ReturningHome(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_succeeded
+        events.action_requests.execute_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_returning_home_state.py
+++ b/tests/isar/state_machine/states/test_returning_home_state.py
@@ -70,11 +70,11 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
 
     current_state = transition(events)
     assert current_state.name is States.Home
-    assert not events.robot_service_events.robot_status_update.check()
+    assert not events.robot_async_events.robot_status_update.check()
 
     event_handler_robot_status: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.robot_status_update
+            events.robot_async_events.robot_status_update
         )
     )
 

--- a/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
+++ b/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
@@ -7,7 +7,7 @@ from isar.state_machine.states_enum import States
 def test_monitor_goes_to_return_home_when_battery_low(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.battery_below_mission_threshold
+        events.robot_async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_mission_state.py
@@ -8,7 +8,7 @@ from robot_interface.models.exceptions.robot_exceptions import ErrorMessage, Err
 def test_stopping_paused_mission_fails(events: Events) -> None:
     current_state = StoppingPausedMission(events, "mission_id")
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_stop
+        events.action_requests.stop_mission.failure
     )
 
     transition = event_handler.handler(
@@ -24,7 +24,7 @@ def test_stopping_paused_mission_fails(events: Events) -> None:
 def test_stopping_paused_mission_succeeds(events: Events) -> None:
     current_state = StoppingPausedMission(events, "mission_id")
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_stopped
+        events.action_requests.stop_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
@@ -33,7 +33,7 @@ def test_stopping_paused_return_home_mission_fails(events: Events) -> None:
     )
     current_state = StoppingPausedReturnHome(events, mission)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_stop
+        events.action_requests.stop_mission.failure
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -50,7 +50,7 @@ def test_stopping_paused_return_home_mission_succeeds(events: Events) -> None:
     )
     current_state = StoppingPausedReturnHome(events, mission)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_stopped
+        events.action_requests.stop_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_return_home_state.py
@@ -47,7 +47,7 @@ def test_stopping_return_home_mission_fails(events: Events) -> None:
     )
     current_state = StoppingReturnHome(events, mission)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_stop
+        events.action_requests.stop_mission.failure
     )
 
     transition = event_handler.handler(
@@ -66,7 +66,7 @@ def test_stopping_return_home_mission_succeeds(events: Events) -> None:
     )
     current_state = StoppingReturnHome(events, mission)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_successfully_stopped
+        events.action_requests.stop_mission.success
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_state.py
+++ b/tests/isar/state_machine/states/test_stopping_state.py
@@ -10,7 +10,7 @@ def test_mqtt_mission_status_sent_on_mission_stopped(events: Events) -> None:
 
     stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.mission_successfully_stopped
+            events.action_requests.stop_mission.success
         )
     )
 
@@ -26,7 +26,7 @@ def test_mqtt_mission_status_sent_on_mission_stopped(events: Events) -> None:
 def test_stopping_mission_fails(events: Events) -> None:
     current_state = Stopping(events, "mission_id")
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_stop
+        events.action_requests.stop_mission.failure
     )
 
     transition = event_handler.handler(

--- a/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
@@ -49,7 +49,7 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
     current_state: State = UnknownStatus(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.robot_status_update
+        events.robot_async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Busy)

--- a/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
@@ -12,7 +12,7 @@ def test_unknown_mission_successfully_stopped(events: Events) -> None:
 
     stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.mission_successfully_stopped
+            events.action_requests.stop_mission.success
         )
     )
 
@@ -32,7 +32,7 @@ def test_unknown_mission_successfully_stopped_with_no_mission_found(
 
     stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.stopped_mission_already_done
+            events.action_requests.stop_mission.success
         )
     )
 
@@ -63,7 +63,7 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
 
     stopping_state_event_handler: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_service_events.mission_successfully_stopped
+            events.action_requests.stop_mission.success
         )
     )
 
@@ -77,7 +77,7 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
 def test_stopping_mission_fails(events: Events) -> None:
     current_state = StoppingUnknownMission(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_service_events.mission_failed_to_stop
+        events.action_requests.stop_mission.failure
     )
 
     transition = event_handler.handler(

--- a/tests/test_persistent_memory.py
+++ b/tests/test_persistent_memory.py
@@ -80,7 +80,7 @@ def test_lockdown_mode(
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
     wait_until(
-        lambda: state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
+        lambda: state_machine_thread_with_db.state_machine.events.robot_async_events.robot_status_update.check()
         == RobotStatus.Home,
         timeout=10.0,
     )
@@ -181,7 +181,7 @@ def test_maintenance_mode(
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
     wait_until(
-        lambda: state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
+        lambda: state_machine_thread_with_db.state_machine.events.robot_async_events.robot_status_update.check()
         == RobotStatus.Home,
         timeout=10.0,
     )
@@ -256,7 +256,7 @@ def test_release_maintenance_mode(
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
     wait_until(
-        lambda: state_machine_thread_with_db.state_machine.events.robot_service_events.robot_status_update.check()
+        lambda: state_machine_thread_with_db.state_machine.events.robot_async_events.robot_status_update.check()
         == RobotStatus.Home,
         timeout=10.0,
     )


### PR DESCRIPTION
This PR not only simplifies the events a bit, but also ensures that related events are cleared before a new result is expected. Previously this was done ad-hoc, leaving it prone to bugs.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.