### PR TITLE
Add grouped GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
       python-major:
         patterns: ["*"]
         update-types: ["major"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds a GitHub Actions entry to the existing `.github/dependabot.yml`, checking `/` weekly on Monday and grouping all update types under `github-actions` with `patterns: ["*"]`. Existing Python entries are preserved; no ignores or automerge are added.

This monitors repository-local action dependencies, not dependencies inside Armada or other composite actions. Workflow/action refs, runner labels, application dependencies, the dormant legacy project-beta action, and Trivy configuration are unchanged.

Validation: parsed with PyYAML, validated against the Dependabot v2 JSON schema, asserted the existing entries are unchanged and the appended entry matches the requested configuration, and checked the diff is limited to `.github/dependabot.yml` with no whitespace errors. Based on current upstream `main`; no duplicate open PR found.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.