### PR TITLE
Preserve transitive dependency updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   # Python dependencies (pyproject.toml + uv.lock).
   - package-ecosystem: uv
     directory: /
+    allow:
+      - dependency-type: all
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/test_and_lint_python_package.yml
+++ b/.github/workflows/test_and_lint_python_package.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - update-dependencies
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Explicitly allow all dependencies in every uv Dependabot entry so transitive version updates remain eligible, preserving the previous `uv lock --upgrade` coverage.
- Remove the obsolete `update-dependencies` push branch filter while retaining main push, pull-request, and manual CI triggers.
- Preserve existing schedules, groups, limits, and other settings; leave GitHub Actions updates, migration workflows, package versions, and the lockfile unchanged.
- Inspected legacy updater PRs without modifying them; none remain open on `update-dependencies`. Manual upgrade documentation remains relevant and unchanged.

## Validation
- `git diff --check` passed.
- Parsed both changed YAML files with existing PyYAML and asserted the exact intended semantic changes, including all uv entries and preserved CI triggers/settings.
- Confirmed no tracked `update-dependencies` / `update_dependencies` references remain and only the two configuration files changed.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like logging, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code as unused imports, functions etc.