### PR TITLE
WIP: Implement mission queue

### DIFF
--- a/src/isar/apis/api.py
+++ b/src/isar/apis/api.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRouter
 from pydantic import AnyHttpUrl
 
-from isar.apis.models.models import ControlMissionResponse, StartMissionResponse
+from isar.apis.models.models import ControlMissionResponse, ScheduleMissionResponse
 from isar.apis.robot_control.robot_controller import RobotController
 from isar.apis.schedule.scheduling_controller import SchedulingController
 from isar.apis.security.authentication import Authenticator
@@ -108,15 +108,15 @@ class API:
         authentication_dependency: Any = Security(self.authenticator.get_scheme())
 
         router.add_api_route(
-            path="/schedule/start-mission",
-            endpoint=self.scheduling_controller.start_mission,
+            path="/schedule/schedule-mission",
+            endpoint=self.scheduling_controller.schedule_mission,
             methods=["POST"],
             dependencies=[authentication_dependency],
-            summary="Start the mission provided in JSON format",
+            summary="Schedule the mission provided in JSON format",
             responses={
                 HTTPStatus.OK.value: {
-                    "description": "Mission succesfully started",
-                    "model": StartMissionResponse,
+                    "description": "Mission succesfully scheduled",
+                    "model": ScheduleMissionResponse,
                 },
                 HTTPStatus.UNPROCESSABLE_ENTITY.value: {
                     "description": "Invalid body - The JSON is incorrect",
@@ -141,7 +141,7 @@ class API:
             responses={
                 HTTPStatus.OK.value: {
                     "description": "Return home mission succesfully started",
-                    "model": StartMissionResponse,
+                    "model": ScheduleMissionResponse,
                 },
                 HTTPStatus.UNPROCESSABLE_ENTITY.value: {
                     "description": "Invalid body - The JSON is incorrect",

--- a/src/isar/apis/models/models.py
+++ b/src/isar/apis/models/models.py
@@ -1,5 +1,4 @@
-from alitra import Frame, Orientation, Pose, Position
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from robot_interface.models.mission.task import TaskTypes
 
@@ -43,48 +42,3 @@ class RobotInfoResponse(BaseModel):
     robot_capabilities: list[str]
     robot_map_name: str
     plant_short_name: str
-
-
-class InputOrientation(BaseModel):
-    x: float
-    y: float
-    z: float
-    w: float
-    frame_name: str = Field(default="robot")
-
-    def to_alitra_orientation(self) -> Orientation:
-        return Orientation(
-            x=self.x,
-            y=self.y,
-            z=self.z,
-            w=self.w,
-            frame=Frame(self.frame_name),
-        )
-
-
-class InputPosition(BaseModel):
-    x: float
-    y: float
-    z: float
-    frame_name: str = Field(default="robot")
-
-    def to_alitra_position(self) -> Position:
-        return Position(
-            x=self.x,
-            y=self.y,
-            z=self.z,
-            frame=Frame(self.frame_name),
-        )
-
-
-class InputPose(BaseModel):
-    position: InputPosition
-    orientation: InputOrientation
-    frame_name: str = Field(default="robot")
-
-    def to_alitra_pose(self) -> Pose:
-        return Pose(
-            position=self.position.to_alitra_position(),
-            orientation=self.orientation.to_alitra_orientation(),
-            frame=Frame(self.frame_name),
-        )

--- a/src/isar/apis/models/models.py
+++ b/src/isar/apis/models/models.py
@@ -9,7 +9,7 @@ class TaskResponse(BaseModel):
     type: TaskTypes
 
 
-class StartMissionResponse(BaseModel):
+class ScheduleMissionResponse(BaseModel):
     id: str
     tasks: list[TaskResponse]
 
@@ -21,8 +21,8 @@ class ControlMissionResponse(BaseModel):
 
 class MissionStartResponse(BaseModel):
     mission_id: str | None = None
-    mission_started: bool
-    mission_not_started_reason: str | None = None
+    mission_scheduled: bool
+    mission_not_scheduled_reason: str | None = None
 
 
 class LockdownResponse(BaseModel):

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -2,9 +2,9 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 
+from alitra import Pose, Position
 from pydantic import BaseModel, Field
 
-from isar.apis.models.models import InputPose, InputPosition
 from isar.config.settings import settings
 from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.task import (
@@ -43,9 +43,9 @@ class AcousticInspectionParameters(BaseModel):
 
 class StartMissionTaskDefinition(BaseModel):
     id: str = Field()
-    pose: InputPose
+    pose: Pose
     type: InspectionTypes = Field(default=InspectionTypes.image)
-    inspection_target: InputPosition
+    inspection_target: Position
     inspection_description: str | None = None
     duration: float | None = None
     acoustic: AcousticInspectionParameters | None = None
@@ -133,13 +133,13 @@ def to_inspection_task(task_definition: StartMissionTaskDefinition) -> TASKS:
 
     kwargs: dict = {
         "id": task_definition.id,
-        "robot_pose": task_definition.pose.to_alitra_pose(),
+        "robot_pose": task_definition.pose,
         "tag_id": task_definition.tag,
         "inspection_description": task_definition.inspection_description,
         "analysis_types": task_definition.analysis_types,
     }
     if spec.needs_target:
-        kwargs["target"] = task_definition.inspection_target.to_alitra_position()
+        kwargs["target"] = task_definition.inspection_target
     if spec.needs_zoom:
         kwargs["zoom"] = task_definition.zoom
     if spec.needs_duration:

--- a/src/isar/apis/models/start_mission_definition.py
+++ b/src/isar/apis/models/start_mission_definition.py
@@ -41,19 +41,15 @@ class AcousticInspectionParameters(BaseModel):
     roi: Roi | None = None
 
 
-class StartMissionInspectionDefinition(BaseModel):
+class StartMissionTaskDefinition(BaseModel):
+    id: str = Field()
+    pose: InputPose
     type: InspectionTypes = Field(default=InspectionTypes.image)
     inspection_target: InputPosition
     inspection_description: str | None = None
     duration: float | None = None
     acoustic: AcousticInspectionParameters | None = None
     analysis_types: list[str] | None = Field(default=None)
-
-
-class StartMissionTaskDefinition(BaseModel):
-    id: str = Field()
-    pose: InputPose
-    inspection: StartMissionInspectionDefinition | None = None
     tag: str | None = None
     zoom: ZoomDescription | None = None
 
@@ -126,40 +122,34 @@ _INSPECTION_SPECS: dict[InspectionTypes, _InspectionSpec] = {
 
 
 def to_inspection_task(task_definition: StartMissionTaskDefinition) -> TASKS:
-    if task_definition.inspection is None:
-        raise ValueError("Inspection in task definition was None")
-
-    inspection_definition = task_definition.inspection
-    spec = _INSPECTION_SPECS.get(inspection_definition.type)
+    spec = _INSPECTION_SPECS.get(task_definition.type)
     if spec is None:
-        raise ValueError(
-            f"Inspection type '{inspection_definition.type}' not supported"
-        )
+        raise ValueError(f"Inspection type '{task_definition.type}' not supported")
 
-    if spec.needs_duration and inspection_definition.duration is None:
+    if spec.needs_duration and task_definition.duration is None:
         raise ValueError(
-            f"No duration given to {inspection_definition.type.value} inspection task"
+            f"No duration given to {task_definition.type.value} inspection task"
         )
 
     kwargs: dict = {
         "id": task_definition.id,
         "robot_pose": task_definition.pose.to_alitra_pose(),
         "tag_id": task_definition.tag,
-        "inspection_description": inspection_definition.inspection_description,
-        "analysis_types": inspection_definition.analysis_types,
+        "inspection_description": task_definition.inspection_description,
+        "analysis_types": task_definition.analysis_types,
     }
     if spec.needs_target:
-        kwargs["target"] = inspection_definition.inspection_target.to_alitra_position()
+        kwargs["target"] = task_definition.inspection_target.to_alitra_position()
     if spec.needs_zoom:
         kwargs["zoom"] = task_definition.zoom
     if spec.needs_duration:
-        kwargs["duration"] = inspection_definition.duration
+        kwargs["duration"] = task_definition.duration
     if spec.needs_acoustic_params:
-        acoustic = inspection_definition.acoustic
+        acoustic = task_definition.acoustic
         if acoustic is None:
             raise ValueError(
                 f"No acoustic parameters given to "
-                f"{inspection_definition.type.value} inspection task"
+                f"{task_definition.type.value} inspection task"
             )
         kwargs["frequency_from"] = acoustic.frequency_from
         kwargs["frequency_to"] = acoustic.frequency_to

--- a/src/isar/apis/schedule/scheduling_controller.py
+++ b/src/isar/apis/schedule/scheduling_controller.py
@@ -6,7 +6,7 @@ from opentelemetry import trace
 
 from isar.apis.models.models import (
     ControlMissionResponse,
-    StartMissionResponse,
+    ScheduleMissionResponse,
     TaskResponse,
 )
 from isar.apis.models.start_mission_definition import (
@@ -30,8 +30,8 @@ class SchedulingController:
         self.scheduling_utilities: SchedulingUtilities = scheduling_utilities
         self.logger = logging.getLogger("api")
 
-    @tracer.start_as_current_span("start_mission")
-    def start_mission(
+    @tracer.start_as_current_span("schedule_mission")
+    def schedule_mission(
         self,
         mission_definition: StartMissionDefinition = Body(
             default=None,
@@ -39,8 +39,8 @@ class SchedulingController:
             title="Mission Definition",
             description="Description of the mission in json format",
         ),
-    ) -> StartMissionResponse:
-        self.logger.info("Received request to start new mission")
+    ) -> ScheduleMissionResponse:
+        self.logger.info("Received request to schedule new mission")
 
         if not mission_definition:
             error_message_no_mission_definition: str = (
@@ -68,8 +68,8 @@ class SchedulingController:
             mission=mission, robot_capabilities=robot_settings.CAPABILITIES
         )
 
-        self.logger.info("Starting mission: %s", mission.id)
-        self.scheduling_utilities.start_mission(mission=mission)
+        self.logger.info("Scheduling mission: %s", mission.id)
+        self.scheduling_utilities.schedule_mission(mission=mission)
         return self._api_response(mission)
 
     @tracer.start_as_current_span("return_home")
@@ -141,8 +141,8 @@ class SchedulingController:
         self.scheduling_utilities.release_maintenance_mode()
         self.logger.info("Maintenance mode successfully released")
 
-    def _api_response(self, mission: Mission) -> StartMissionResponse:
-        return StartMissionResponse(
+    def _api_response(self, mission: Mission) -> ScheduleMissionResponse:
+        return ScheduleMissionResponse(
             id=mission.id,
             tasks=[self._task_api_response(task) for task in mission.tasks],
         )

--- a/src/isar/config/settings.py
+++ b/src/isar/config/settings.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
 
     USE_DB: bool = Field(default=False)
 
+    # The maximum number of pending missions
+    MISSION_QUEUE_MAX_SIZE: int = Field(default=100)
+
     # Determines which robot package ISAR will attempt to import
     # Name must match with an installed python package in the local environment
     ROBOT_PACKAGE: str = Field(default="isar_robot")
@@ -58,6 +61,9 @@ class Settings(BaseSettings):
 
     # Number of attempts to stop the robot before giving up
     UPLOAD_FAILURE_MAX_WAIT: int = Field(default=60)
+
+    # Frequency at which the mission queue is updated and published on mqtt
+    MISSION_QUEUE_REFRESH_INTERVAL: float = Field(default=10.0)
 
     # ISAR telemetry intervals
     ROBOT_HEARTBEAT_PUBLISH_INTERVAL: float = Field(default=1)
@@ -192,6 +198,9 @@ class Settings(BaseSettings):
     TOPIC_ISAR_STARTUP: str = Field(default="startup", validate_default=True)
     TOPIC_ISAR_INTERVENTION_NEEDED: str = Field(
         default="intervention_needed", validate_default=True
+    )
+    TOPIC_ISAR_MISSION_QUEUE: str = Field(
+        default="mission_queue", validate_default=True
     )
 
     # List of MQTT Topics Expiry

--- a/src/isar/models/events.py
+++ b/src/isar/models/events.py
@@ -88,7 +88,7 @@ class Events:
 
         self.api_requests: APIRequests = APIRequests()
         self.action_requests: RobotActionRequests = RobotActionRequests()
-        self.robot_async_events: RobotAsyncEvents = RobotAsyncEvents()
+        self.async_events: AsyncEvents = AsyncEvents()
 
         self.upload_inspection_event: Event[tuple[Inspection, Mission]] = Event(
             "uploader", maxsize=10
@@ -127,8 +127,9 @@ class APIEvent[T1, T2]:
 
 class APIRequests:
     def __init__(self) -> None:
-        self.start_mission: APIEvent[Mission, MissionStartResponse] = APIEvent(
-            "start_mission"
+        self.schedule_mission: APIEvent[Mission, MissionStartResponse] = APIEvent(
+            "schedule_mission",
+            prioritized=True,  # Prioritized since it is accepted in any state
         )
         self.stop_mission: APIEvent[EmptyMessage, ControlMissionResponse] = APIEvent(
             "stop_mission"
@@ -199,7 +200,7 @@ class RobotActionRequests:
         ] = RobotActionEvent("resume_mission")
 
 
-class RobotAsyncEvents:
+class AsyncEvents:
     def __init__(self) -> None:
         self.robot_status_update: Event[RobotStatus] = Event("robot_status_update")
         self.battery_below_mission_threshold: Event[EmptyMessage] = Event(
@@ -208,3 +209,4 @@ class RobotAsyncEvents:
         self.battery_above_recharge_threshold: Event[EmptyMessage] = Event(
             "battery_above_recharge_threshold"
         )
+        self.mission_ready: Event[Mission] = Event("mission_ready")

--- a/src/isar/robot/robot_service.py
+++ b/src/isar/robot/robot_service.py
@@ -4,11 +4,11 @@ from threading import Event as ThreadEvent
 
 from isar.models.events import (
     AbortedMission,
+    AsyncEvents,
     EmptyMessage,
     Event,
     Events,
     RobotActionRequests,
-    RobotAsyncEvents,
 )
 from isar.models.mqtt_queue import MQTTQueue
 from isar.robot.robot_battery import RobotBatteryThread
@@ -34,7 +34,7 @@ class RobotService:
     ) -> None:
         self.logger = logging.getLogger("robot")
         self.action_requests: RobotActionRequests = events.action_requests
-        self.robot_async_events: RobotAsyncEvents = events.robot_async_events
+        self.robot_async_events: AsyncEvents = events.async_events
         self.mqtt_queue: MQTTQueue = mqtt_queue
         self.upload_task_event: Event[tuple[InspectionTask, Mission]] = (
             events.upload_task_event

--- a/src/isar/robot/robot_status.py
+++ b/src/isar/robot/robot_status.py
@@ -3,7 +3,7 @@ import time
 from threading import Event, Thread
 
 from isar.config.settings import settings
-from isar.models.events import RobotAsyncEvents
+from isar.models.events import AsyncEvents
 from robot_interface.models.exceptions.robot_exceptions import RobotException
 from robot_interface.robot_interface import RobotInterface
 
@@ -13,10 +13,10 @@ class RobotStatusThread(Thread):
         self,
         robot: RobotInterface,
         signal_exit: Event,
-        robot_async_events: RobotAsyncEvents,
+        robot_async_events: AsyncEvents,
     ):
         self.logger = logging.getLogger("robot")
-        self.robot_async_events: RobotAsyncEvents = robot_async_events
+        self.robot_async_events: AsyncEvents = robot_async_events
         self.robot: RobotInterface = robot
         self.signal_exit: Event = signal_exit
         self.robot_status_poll_interval: float = settings.ROBOT_API_STATUS_POLL_INTERVAL

--- a/src/isar/script.py
+++ b/src/isar/script.py
@@ -14,6 +14,7 @@ from isar.models.events import Events
 from isar.modules import ApplicationContainer, get_injector
 from isar.robot.robot_inspection_service import RobotInspectionService
 from isar.robot.robot_service import RobotService
+from isar.services.mission_queue.mission_queue_service import MissionQueueService
 from isar.services.service_connections.mqtt.mqtt_client import MqttClient
 from isar.services.service_connections.mqtt.robot_heartbeat_publisher import (
     RobotHeartbeatPublisher,
@@ -108,6 +109,10 @@ def start() -> None:
     )
     inspection_service_thread.start()
     threads.append(inspection_service_thread)
+
+    mission_queue_service_thread: MissionQueueService = MissionQueueService(events)
+    mission_queue_service_thread.start()
+    threads.append(mission_queue_service_thread)
 
     robot_service_thread: Thread = Thread(
         target=robot.run, name="Robot service", daemon=True

--- a/src/isar/services/mission_queue/mission_queue_service.py
+++ b/src/isar/services/mission_queue/mission_queue_service.py
@@ -1,0 +1,83 @@
+import logging
+import time
+from datetime import UTC, datetime
+from threading import Thread
+
+from isar.apis.models.models import MissionStartResponse
+from isar.config.settings import settings
+from isar.models.events import APIEvent, Event, Events
+from isar.models.mqtt_queue import MQTTQueue
+from robot_interface.models.mission.mission import Mission
+from robot_interface.telemetry.payloads import MissionQueuePayload
+
+
+class MissionQueueService(Thread):
+    def __init__(
+        self,
+        events: Events,
+    ):
+        self.logger = logging.getLogger("robot")
+        self.schedule_mission_event: APIEvent[Mission, MissionStartResponse] = (
+            events.api_requests.schedule_mission
+        )
+        self.mission_ready_event: Event[Mission] = events.async_events.mission_ready
+        self.signal_exit: Event = events.signal_state_machine_exit
+        self.mqtt_queue: MQTTQueue = events.mqtt_queue
+        Thread.__init__(self, name="Mission Queue Service thread")
+
+    def stop(self) -> None:
+        return
+
+    def run(self) -> None:
+
+        mission_queue: Event[Mission] = Event(
+            "mission_queue", maxsize=settings.MISSION_QUEUE_MAX_SIZE
+        )
+
+        while not self.signal_exit.has_event():
+
+            time.sleep(settings.MISSION_QUEUE_REFRESH_INTERVAL)
+
+            payload: MissionQueuePayload = MissionQueuePayload(
+                isar_id=settings.ISAR_ID,
+                robot_name=settings.ROBOT_NAME,
+                mission_queue=list(mission_queue.queue),
+            )
+
+            self.mqtt_queue.publish(
+                topic=settings.TOPIC_ISAR_MISSION_QUEUE,
+                payload=payload.model_dump_json(),
+            )
+
+            requested_mission = self.schedule_mission_event.request.consume_event()
+            if requested_mission is not None:
+                if mission_queue.full():
+                    self.schedule_mission_event.trigger_response(
+                        MissionStartResponse(
+                            mission_scheduled=False,
+                            mission_not_scheduled_reason="Mission queue is full",
+                        )
+                    )
+                else:
+                    mission_queue.trigger_event(requested_mission)
+                    # TODO: use insertion sort for appending it to the queue using start time. Start time None is prioritised. Existing missions are prioritised
+                    self.schedule_mission_event.trigger_response(
+                        MissionStartResponse(mission_scheduled=True)
+                    )
+
+            if self.mission_ready_event.has_event():
+                continue
+
+            pending_mission = mission_queue.check()
+            if pending_mission is not None and (
+                pending_mission.start_time is None
+                or pending_mission.start_time > datetime.now(UTC)
+            ):
+                pending_mission = mission_queue.consume_event()
+                if pending_mission is None:
+                    self.logger.warning(
+                        "Mission was removed from queue before it could be started"
+                    )
+                self.mission_ready_event.trigger_event(pending_mission)
+
+        self.logger.info("Exiting robot status thread")

--- a/src/isar/services/utilities/scheduling_utilities.py
+++ b/src/isar/services/utilities/scheduling_utilities.py
@@ -73,13 +73,13 @@ class SchedulingUtilities:
             )
         log_statement: str = "\n".join(log_statements)
 
-        self.logger.info("Started mission:\n%s", log_statement)
+        self.logger.info("Scheduled mission:\n%s", log_statement)
 
-    def start_mission(
+    def schedule_mission(
         self,
         mission: Mission,
     ) -> None:
-        """Start mission
+        """Schedule mission
 
         Raises
         ------
@@ -92,22 +92,22 @@ class SchedulingUtilities:
         """
         try:
             self.logger.info(
-                "Requesting to start mission:\n"
+                "Requesting to schedule mission:\n"
                 f"  Mission ID: {mission.id}\n"
                 f"  Mission Name: {mission.name}\n"
                 f"  Number of Tasks: {len(mission.tasks)}"
             )
-            mission_start_response = self._send_command(
+            mission_schedule_response = self._send_command(
                 deepcopy(mission),
-                self.api_events.start_mission,
+                self.api_events.schedule_mission,
             )
-            if not mission_start_response.mission_started:
+            if not mission_schedule_response.mission_scheduled:
                 self.logger.warning(
-                    f"Mission failed to start - {mission_start_response.mission_not_started_reason}"
+                    f"Mission failed to schedule - {mission_schedule_response.mission_not_scheduled_reason}"
                 )
                 raise HTTPException(
                     status_code=HTTPStatus.CONFLICT,
-                    detail=mission_start_response.mission_not_started_reason,
+                    detail=mission_schedule_response.mission_not_scheduled_reason,
                 )
         except EventConflictError:
             error_message = "Previous mission request is still being processed"
@@ -115,12 +115,12 @@ class SchedulingUtilities:
             raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
         except EventTimeoutError:
             error_message = (
-                "State machine has entered a state which cannot start a mission"
+                "State machine has entered a state which cannot schedule a mission"
             )
             self.logger.warning(error_message)
             raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=error_message)
         self.log_mission_overview(mission)
-        self.logger.info("OK - Mission start successfully initiated")
+        self.logger.info("OK - Mission schedule successfully initiated")
 
     def return_home(
         self,

--- a/src/isar/state_machine/states/await_next_mission.py
+++ b/src/isar/state_machine/states/await_next_mission.py
@@ -20,7 +20,7 @@ def AwaitNextMission(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[Mission](
-            event=events.api_requests.start_mission.request,
+            event=events.api_requests.schedule_mission.request,
             handler=lambda mission: Monitor.transition_and_start_mission(mission, True),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -36,7 +36,7 @@ def AwaitNextMission(events: Events) -> State:
             handler=lambda _: GoingToLockdown.transition_and_start_mission_and_report_to_api(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_below_mission_threshold,
+            event=events.async_events.battery_below_mission_threshold,
             handler=lambda _: GoingToRecharging.transition_and_start_return_home(),
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/home.py
+++ b/src/isar/state_machine/states/home.py
@@ -31,7 +31,7 @@ def Home(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[Mission](
-            event=events.api_requests.start_mission.request,
+            event=events.async_events.mission_ready,
             handler=lambda mission: Monitor.transition_and_start_mission(mission, True),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -43,7 +43,7 @@ def Home(events: Events) -> State:
             handler=lambda _: StoppingUnknownMission.transition_and_respond_to_API(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_async_events.robot_status_update,
+            event=events.async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](
@@ -51,7 +51,7 @@ def Home(events: Events) -> State:
             handler=lambda _: Lockdown.transition_and_respond_to_api(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_below_mission_threshold,
+            event=events.async_events.battery_below_mission_threshold,
             handler=lambda _: Recharging.transition(),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -69,7 +69,7 @@ def Home(events: Events) -> State:
 def transition() -> Transition:
     def _transition(events: Events) -> State:
         # This clears the current robot status value, so we don't read an outdated value
-        events.robot_async_events.robot_status_update.clear_event()
+        events.async_events.robot_status_update.clear_event()
 
         return Home(events)
 

--- a/src/isar/state_machine/states/intervention_needed.py
+++ b/src/isar/state_machine/states/intervention_needed.py
@@ -37,7 +37,7 @@ def InterventionNeeded(events: Events) -> State:
             handler=lambda _: Maintenance.transition_and_reply_to_API(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_async_events.robot_status_update,
+            event=events.async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
     ]

--- a/src/isar/state_machine/states/monitor.py
+++ b/src/isar/state_machine/states/monitor.py
@@ -55,7 +55,7 @@ def Monitor(events: Events, mission_id: str) -> State:
             handler=_mission_success_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_below_mission_threshold,
+            event=events.async_events.battery_below_mission_threshold,
             handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
         ),
         EventHandlerMapping[EmptyMessage](
@@ -89,8 +89,8 @@ def transition_and_start_mission(
         )
 
         if should_respond_to_API_request:
-            events.api_requests.start_mission.trigger_response(
-                MissionStartResponse(mission_started=True)
+            events.api_requests.schedule_mission.trigger_response(
+                MissionStartResponse(mission_scheduled=True)
             )
         return Monitor(events, mission_id=mission.id)
 

--- a/src/isar/state_machine/states/offline.py
+++ b/src/isar/state_machine/states/offline.py
@@ -27,7 +27,7 @@ def Offline(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[RobotStatus](
-            event=events.robot_async_events.robot_status_update,
+            event=events.async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/paused.py
+++ b/src/isar/state_machine/states/paused.py
@@ -24,7 +24,7 @@ def Paused(events: Events, mission_id: str) -> State:
             ),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_below_mission_threshold,
+            event=events.async_events.battery_below_mission_threshold,
             handler=lambda _: StoppingGoToRecharge.transition_and_stop_mission(),
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/recharging.py
+++ b/src/isar/state_machine/states/recharging.py
@@ -12,11 +12,11 @@ def Recharging(events: Events) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_above_recharge_threshold,
+            event=events.async_events.battery_above_recharge_threshold,
             handler=lambda _: Home.transition(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_async_events.robot_status_update,
+            event=events.async_events.robot_status_update,
             handler=lambda robot_status: (
                 Offline.transition() if robot_status == RobotStatus.Offline else None
             ),

--- a/src/isar/state_machine/states/recharging_with_mission.py
+++ b/src/isar/state_machine/states/recharging_with_mission.py
@@ -22,13 +22,13 @@ def RechargingWithMission(events: Events, mission: AbortedMission) -> State:
 
     event_handlers: list[EventHandlerMapping] = [
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_above_recharge_threshold,
+            event=events.async_events.battery_above_recharge_threshold,
             handler=lambda _: Monitor.transition_and_start_mission(
                 mission, should_respond_to_API_request=False
             ),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_async_events.robot_status_update,
+            event=events.async_events.robot_status_update,
             handler=lambda robot_status: (
                 Offline.transition() if robot_status == RobotStatus.Offline else None
             ),

--- a/src/isar/state_machine/states/return_home_paused.py
+++ b/src/isar/state_machine/states/return_home_paused.py
@@ -24,11 +24,11 @@ def ReturnHomePaused(events: Events) -> State:
             handler=lambda _: ResumingReturnHome.transition_and_resume_mission_and_reply_to_API(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_below_mission_threshold,
+            event=events.async_events.battery_below_mission_threshold,
             handler=lambda _: ReturningHome.transition_to_existing_mission(),
         ),
         EventHandlerMapping[Mission](
-            event=events.api_requests.start_mission.request,
+            event=events.async_events.mission_ready,
             handler=lambda mission: StoppingPausedReturnHome.transition_and_stop_return_home_and_reply_to_API(
                 mission
             ),

--- a/src/isar/state_machine/states/returning_home.py
+++ b/src/isar/state_machine/states/returning_home.py
@@ -38,7 +38,7 @@ def ReturningHome(
             handler=_mission_failed_event_handler,
         ),
         EventHandlerMapping[Mission](
-            event=events.api_requests.start_mission.request,
+            event=events.async_events.mission_ready,
             handler=lambda mission: StoppingReturnHome.transition_and_stop_return_home_and_reply_to_API(
                 mission
             ),
@@ -48,7 +48,7 @@ def ReturningHome(
             handler=lambda _: Home.transition(),
         ),
         EventHandlerMapping[EmptyMessage](
-            event=events.robot_async_events.battery_below_mission_threshold,
+            event=events.async_events.battery_below_mission_threshold,
             handler=lambda _: GoingToRecharging.transition_to_existing_mission(),
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/isar/state_machine/states/stopping_paused_return_home.py
+++ b/src/isar/state_machine/states/stopping_paused_return_home.py
@@ -36,9 +36,9 @@ def transition_and_stop_return_home_and_reply_to_API(
 
         response = MissionStartResponse(
             mission_id=mission.id,
-            mission_started=True,
+            mission_scheduled=True,
         )
-        events.api_requests.start_mission.trigger_response(response)
+        events.api_requests.schedule_mission.trigger_response(response)
 
         return StoppingPausedReturnHome(events, mission)
 

--- a/src/isar/state_machine/states/stopping_return_home.py
+++ b/src/isar/state_machine/states/stopping_return_home.py
@@ -33,9 +33,9 @@ def transition_and_stop_return_home_and_reply_to_API(
         events.action_requests.stop_mission.trigger_request(EmptyMessage())
         response = MissionStartResponse(
             mission_id=mission.id,
-            mission_started=True,
+            mission_scheduled=True,
         )
-        events.api_requests.start_mission.trigger_response(response)
+        events.api_requests.schedule_mission.trigger_response(response)
         return StoppingReturnHome(events, mission)
 
     return _transition

--- a/src/isar/state_machine/states/unknown_status.py
+++ b/src/isar/state_machine/states/unknown_status.py
@@ -32,7 +32,7 @@ def UnknownStatus(events: Events) -> State:
             handler=lambda _: StoppingUnknownMission.transition_and_respond_to_API(),
         ),
         EventHandlerMapping[RobotStatus](
-            event=events.robot_async_events.robot_status_update,
+            event=events.async_events.robot_status_update,
             handler=_robot_status_event_handler,
         ),
         EventHandlerMapping[EmptyMessage](

--- a/src/robot_interface/models/mission/mission.py
+++ b/src/robot_interface/models/mission/mission.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -12,6 +13,7 @@ class Mission(BaseModel):
     tasks: list[TASKS] = Field(default_factory=list, frozen=True)
     name: str = Field(frozen=True)
     status: MissionStatus = MissionStatus.NotStarted
+    start_time: datetime | None = Field(default=None, frozen=True)
     error_message: ErrorMessage | None = Field(default=None)
 
     def _is_return_to_home_mission(self) -> bool:

--- a/src/robot_interface/telemetry/payloads.py
+++ b/src/robot_interface/telemetry/payloads.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from isar.models.status import IsarStatus
 from isar.storage.storage_interface import BlobStoragePath
 from robot_interface.models.exceptions.robot_exceptions import ErrorReason
+from robot_interface.models.mission.mission import Mission
 from robot_interface.models.mission.status import MissionStatus, TaskStatus
 from robot_interface.models.mission.task import TaskTypes
 from robot_interface.models.robots.battery_state import BatteryState
@@ -59,6 +60,12 @@ class RobotInfoPayload(BaseModel):
     port: int
     capabilities: list[str]
     timestamp: datetime
+
+
+class MissionQueuePayload(BaseModel):
+    isar_id: str
+    robot_name: str
+    mission_queue: list[Mission]
 
 
 class RobotHeartbeatPayload(BaseModel):

--- a/tests/isar/apis/models/example_mission_definition.json
+++ b/tests/isar/apis/models/example_mission_definition.json
@@ -3,7 +3,6 @@
   "name": "my-mission",
   "tasks": [
     {
-      "type": "inspection",
       "pose": {
         "position": {
           "x": 0,
@@ -20,17 +19,14 @@
         },
         "frame_name": "robot"
       },
-      "inspection": {
-        "type": "Image",
-        "inspection_target": {
-          "x": 0,
-          "y": 0,
-          "z": 0,
-          "frame_name": "robot"
-        },
-        "analysis_types": ["anonymize"],
-        "id": "generated_inspection_id"
+      "type": "Image",
+      "inspection_target": {
+        "x": 0,
+        "y": 0,
+        "z": 0,
+        "frame_name": "robot"
       },
+      "analysis_types": ["anonymize"],
       "tag": "MY-TAG-123",
       "id": "generated_task_id"
     }

--- a/tests/isar/apis/models/example_mission_definition.json
+++ b/tests/isar/apis/models/example_mission_definition.json
@@ -8,23 +8,31 @@
           "x": 0,
           "y": 0,
           "z": 0,
-          "frame_name": "robot"
+          "frame": {
+            "name": "robot"
+          }
         },
         "orientation": {
           "x": 0,
           "y": 0,
           "z": 0,
           "w": 0,
-          "frame_name": "robot"
+          "frame": {
+            "name": "robot"
+          }
         },
-        "frame_name": "robot"
+        "frame": {
+          "name": "robot"
+        }
       },
       "type": "Image",
       "inspection_target": {
         "x": 0,
         "y": 0,
         "z": 0,
-        "frame_name": "robot"
+        "frame": {
+          "name": "robot"
+        }
       },
       "analysis_types": ["anonymize"],
       "tag": "MY-TAG-123",

--- a/tests/isar/apis/models/test_start_mission_definition.py
+++ b/tests/isar/apis/models/test_start_mission_definition.py
@@ -4,7 +4,6 @@ import os
 import pytest
 from alitra import Frame, Orientation, Pose, Position
 
-from isar.apis.models.models import InputOrientation, InputPose, InputPosition
 from isar.apis.models.start_mission_definition import (
     InspectionTypes,
     StartMissionDefinition,
@@ -23,15 +22,16 @@ from robot_interface.models.mission.task import (
 def test_to_isar_mission() -> None:
     DUMMY_MISSION_NAME = "mission_name"
 
-    task_pose = InputPose(
-        position=InputPosition(x=1, y=1, z=1),
-        orientation=InputOrientation(x=1, y=1, z=1, w=1),
+    task_pose = Pose(
+        position=Position(x=1, y=1, z=1, frame=Frame("robot")),
+        orientation=Orientation(x=1, y=1, z=1, w=1, frame=Frame("robot")),
+        frame=Frame("robot"),
     )
     task_definition = StartMissionTaskDefinition(
         id="test-id",
         pose=task_pose,
         type=InspectionTypes.image,
-        inspection_target=InputPosition(x=1, y=1, z=1),
+        inspection_target=Position(x=1, y=1, z=1, frame=Frame("robot")),
     )
     mission_definition = StartMissionDefinition(
         tasks=[task_definition], name=DUMMY_MISSION_NAME, id="test-id2"
@@ -92,8 +92,15 @@ def _build_mission_with_inspection_payload(inspection_payload: dict) -> Mission:
                 "id": "dummy_id",
                 "type": "inspection",
                 "pose": {
-                    "position": {"x": 0, "y": 0, "z": 0},
-                    "orientation": {"x": 0, "y": 0, "z": 0, "w": 1},
+                    "position": {"x": 0, "y": 0, "z": 0, "frame": {"name": "robot"}},
+                    "orientation": {
+                        "x": 0,
+                        "y": 0,
+                        "z": 0,
+                        "w": 1,
+                        "frame": {"name": "robot"},
+                    },
+                    "frame": {"name": "robot"},
                 },
                 **inspection_payload,
             }
@@ -111,7 +118,7 @@ def test_analysis_types_defaults_to_none_for_all_inspection_types(
 ) -> None:
     payload: dict = {
         "type": inspection_type,
-        "inspection_target": {"x": 0, "y": 0, "z": 0},
+        "inspection_target": {"x": 0, "y": 0, "z": 0, "frame": {"name": "robot"}},
     }
     if inspection_type in {"Video", "ThermalVideo", "Audio"}:
         payload["duration"] = 1.0
@@ -132,7 +139,7 @@ def test_analysis_types_defaults_to_none_for_all_inspection_types(
 def _acoustic_payload(roi: dict | None = None) -> dict:
     payload: dict = {
         "type": "AcousticMeasurement",
-        "inspection_target": {"x": 0, "y": 0, "z": 0},
+        "inspection_target": {"x": 0, "y": 0, "z": 0, "frame": {"name": "robot"}},
         "acoustic": {
             "frequency_from": 35000.0,
             "frequency_to": 40000.0,

--- a/tests/isar/apis/models/test_start_mission_definition.py
+++ b/tests/isar/apis/models/test_start_mission_definition.py
@@ -8,7 +8,6 @@ from isar.apis.models.models import InputOrientation, InputPose, InputPosition
 from isar.apis.models.start_mission_definition import (
     InspectionTypes,
     StartMissionDefinition,
-    StartMissionInspectionDefinition,
     StartMissionTaskDefinition,
     to_isar_mission,
 )
@@ -24,10 +23,6 @@ from robot_interface.models.mission.task import (
 def test_to_isar_mission() -> None:
     DUMMY_MISSION_NAME = "mission_name"
 
-    inspection_definition = StartMissionInspectionDefinition(
-        type=InspectionTypes.image,
-        inspection_target=InputPosition(x=1, y=1, z=1),
-    )
     task_pose = InputPose(
         position=InputPosition(x=1, y=1, z=1),
         orientation=InputOrientation(x=1, y=1, z=1, w=1),
@@ -35,7 +30,8 @@ def test_to_isar_mission() -> None:
     task_definition = StartMissionTaskDefinition(
         id="test-id",
         pose=task_pose,
-        inspection=inspection_definition,
+        type=InspectionTypes.image,
+        inspection_target=InputPosition(x=1, y=1, z=1),
     )
     mission_definition = StartMissionDefinition(
         tasks=[task_definition], name=DUMMY_MISSION_NAME, id="test-id2"
@@ -99,7 +95,7 @@ def _build_mission_with_inspection_payload(inspection_payload: dict) -> Mission:
                     "position": {"x": 0, "y": 0, "z": 0},
                     "orientation": {"x": 0, "y": 0, "z": 0, "w": 1},
                 },
-                "inspection": inspection_payload,
+                **inspection_payload,
             }
         ],
     }

--- a/tests/isar/apis/scheduler/test_scheduler_router.py
+++ b/tests/isar/apis/scheduler/test_scheduler_router.py
@@ -48,7 +48,7 @@ mock_return_control_mission_stop_wrong_id_response = mock.Mock(
 
 
 class TestStartMission:
-    schedule_start_mission_path = "/schedule/start-mission"
+    schedule_start_mission_path = "/schedule/schedule-mission"
     dummy_start_mission_definition = (
         DummyMissionDefinition.dummy_start_mission_definition
     )
@@ -62,8 +62,8 @@ class TestStartMission:
     @mock.patch.object(
         SchedulingUtilities, "_verify_valid_state", lambda self, event: None
     )
-    @mock.patch.object(SchedulingUtilities, "start_mission", mock_void)
-    def test_start_mission(self, client: TestClient) -> None:
+    @mock.patch.object(SchedulingUtilities, "schedule_mission", mock_void)
+    def test_schedule_mission(self, client: TestClient) -> None:
         response = client.post(
             url=self.schedule_start_mission_path,
             json=jsonable_encoder(self.dummy_start_mission_content),
@@ -90,21 +90,21 @@ class TestStartMission:
         SchedulingUtilities, "_verify_valid_state", lambda self, event: None
     )
     @mock.patch.object(SchedulingUtilities, "_send_command", mock_queue_timeout_error)
-    def test_start_mission_timeout(self, client: TestClient) -> None:
+    def test_schedule_mission_timeout(self, client: TestClient) -> None:
         response = client.post(
             url=self.schedule_start_mission_path,
             json=jsonable_encoder(self.dummy_start_mission_content),
         )
         assert response.status_code == HTTPStatus.CONFLICT
         assert response.json() == {
-            "detail": "State machine has entered a state which cannot start a mission"
+            "detail": "State machine has entered a state which cannot schedule a mission"
         }
 
     @mock.patch.object(
         SchedulingUtilities, "_verify_valid_state", lambda self, event: None
     )
     @mock.patch("isar.config.settings.robot_settings.CAPABILITIES", [])
-    @mock.patch.object(SchedulingUtilities, "start_mission", mock_void)
+    @mock.patch.object(SchedulingUtilities, "schedule_mission", mock_void)
     def test_robot_not_capable(self, client: TestClient) -> None:
         response = client.post(
             url=self.schedule_start_mission_path,

--- a/tests/isar/apis/security/test_authentication.py
+++ b/tests/isar/apis/security/test_authentication.py
@@ -27,7 +27,7 @@ def stub_access_token() -> str:
 class TestAuthentication:
     @pytest.mark.parametrize(
         "query_string",
-        ["start-mission?ID=1", "stop-mission"],
+        ["schedule-mission?ID=1", "stop-mission"],
     )
     def test_authentication(
         self,

--- a/tests/isar/models/communication/test_events.py
+++ b/tests/isar/models/communication/test_events.py
@@ -4,14 +4,14 @@ from isar.models.events import Event, Events
 class TestEvents:
     def test_events(self) -> None:
         events: Events = Events()
-        assert events.api_requests.start_mission is not None
+        assert events.api_requests.schedule_mission is not None
         assert (
-            events.api_requests.start_mission.request is not None
-            and events.api_requests.start_mission.request.maxsize == 1
+            events.api_requests.schedule_mission.request is not None
+            and events.api_requests.schedule_mission.request.maxsize == 1
         )
         assert (
-            events.api_requests.start_mission.response is not None
-            and events.api_requests.start_mission.response.maxsize == 1
+            events.api_requests.schedule_mission.response is not None
+            and events.api_requests.schedule_mission.response.maxsize == 1
         )
         assert events.api_requests.stop_mission is not None
         assert (

--- a/tests/isar/services/utilities/test_scheduling_utilities.py
+++ b/tests/isar/services/utilities/test_scheduling_utilities.py
@@ -133,11 +133,37 @@ def test_state_machine_ready_to_receive_mission(
     all_states = list(states.keys())
 
     event_mappings: dict[APIEvent, list[States]] = {
-        api_events.start_mission: [
-            States.Home,
-            States.AwaitNextMission,
+        api_events.schedule_mission: [
+            States.Monitor,
             States.ReturningHome,
+            States.Stopping,
+            States.StoppingUnknownMission,
+            States.StoppingReturnHome,
+            States.Paused,
+            States.Pausing,
+            States.Resuming,
+            States.PausingReturnHome,
+            States.ResumingReturnHome,
             States.ReturnHomePaused,
+            States.AwaitNextMission,
+            States.Home,
+            States.Offline,
+            States.UnknownStatus,
+            States.InterventionNeeded,
+            States.Recharging,
+            States.RechargingWithMission,
+            States.StoppingGoToLockdown,
+            States.GoingToLockdown,
+            States.Lockdown,
+            States.GoingToRecharging,
+            States.GoingToRechargingWithMission,
+            States.StoppingGoToRecharge,
+            States.Maintenance,
+            States.StoppingDueToMaintenance,
+            States.StoppingPausedMission,
+            States.StoppingPausedReturnHome,
+            States.GoingToLockdownWithMission,
+            States.LockdownWithMission,
         ],
         api_events.stop_mission: [
             States.Monitor,
@@ -193,13 +219,13 @@ def test_mission_already_started_causes_conflict(
 ) -> None:
     mocker.patch.object(settings, "QUEUE_TIMEOUT", 2)
     start_mission_thread: Thread = Thread(
-        target=scheduling_utilities.start_mission,
+        target=scheduling_utilities.schedule_mission,
         args=[DummyMissionDefinition.default_mission],
     )
     start_mission_thread.start()
 
     with pytest.raises(HTTPException) as err:
-        scheduling_utilities.start_mission(DummyMissionDefinition.default_mission)
+        scheduling_utilities.schedule_mission(DummyMissionDefinition.default_mission)
     start_mission_thread.join()
     assert err.value.status_code == HTTPStatus.CONFLICT
 

--- a/tests/isar/state_machine/states/test_await_next_mission_state.py
+++ b/tests/isar/state_machine/states/test_await_next_mission_state.py
@@ -49,7 +49,7 @@ def test_state_machine_with_successful_mission_stop(
     wait_until(
         lambda: States.Home in state_machine_thread.state_machine.transitions_list
     )
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
     wait_until(
         lambda: state_machine_thread.state_machine.current_state.name == States.Monitor
     )
@@ -93,7 +93,7 @@ def test_unknown_status_transitions_to_await_next_mission_if_it_was_already_avai
     current_state = UnknownStatus(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.robot_status_update
+        events.async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Available)

--- a/tests/isar/state_machine/states/test_going_to_recharging_state.py
+++ b/tests/isar/state_machine/states/test_going_to_recharging_state.py
@@ -41,7 +41,7 @@ def test_stopping_to_recharge_goes_to_going_to_recharging_with_aborted_mission(
 def test_return_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = ReturningHome(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.battery_below_mission_threshold
+        events.async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_home_state.py
+++ b/tests/isar/state_machine/states/test_home_state.py
@@ -61,7 +61,7 @@ def test_intervention_needed_transitions_to_home_if_robot_is_home(
     current_state = InterventionNeeded(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.robot_status_update
+        events.async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Home)
@@ -76,7 +76,7 @@ def test_recharging_goes_to_home_when_battery_high(events: Events) -> None:
     current_state = Recharging(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.battery_above_recharge_threshold
+        events.async_events.battery_above_recharge_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_intervention_needed_state.py
+++ b/tests/isar/state_machine/states/test_intervention_needed_state.py
@@ -108,7 +108,7 @@ def test_intervention_needed_transitions_does_not_transition_if_status_is_not_ho
     current_state = InterventionNeeded(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.robot_status_update
+        events.async_events.robot_status_update
     )
 
     statuses = [

--- a/tests/isar/state_machine/states/test_maintenance_mode_state.py
+++ b/tests/isar/state_machine/states/test_maintenance_mode_state.py
@@ -13,7 +13,7 @@ def test_home_transitions_to_maintenance_mode_when_teleoperating(
     current_state = Home(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.robot_status_update
+        events.async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
@@ -30,7 +30,7 @@ def test_unknown_status_transitions_to_maintenance_mode_when_teleoperating(
     current_state = UnknownStatus(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.robot_status_update
+        events.async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)
@@ -47,7 +47,7 @@ def test_offline_transitions_to_maintenance_mode_when_teleoperating(
     current_state = Offline(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.robot_status_update
+        events.async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.TeleOperation)

--- a/tests/isar/state_machine/states/test_monitor_state.py
+++ b/tests/isar/state_machine/states/test_monitor_state.py
@@ -140,7 +140,7 @@ def test_state_machine_with_unsuccessful_mission_stop(
         in state_machine_thread.state_machine.transitions_list,
         timeout=10,
     )
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
     wait_until(
         lambda: state_machine_thread.state_machine.current_state.name == States.Monitor
     )
@@ -183,7 +183,7 @@ def test_robot_mission_status_exception_handling(
         timeout=10,
     )
 
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
 
     expected_transitions = deque(
         [
@@ -203,7 +203,7 @@ def test_transition_from_monitor_to_stopping_to_recharge(events: Events) -> None
     current_state = Monitor(events, "test_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.battery_below_mission_threshold
+        events.async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_paused_state.py
+++ b/tests/isar/state_machine/states/test_paused_state.py
@@ -37,7 +37,7 @@ def test_transition_from_paused_to_stopping_to_recharge(events: Events) -> None:
     current_state = Paused(events, "test_id")
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.battery_below_mission_threshold
+        events.async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_recharging_state.py
+++ b/tests/isar/state_machine/states/test_recharging_state.py
@@ -21,7 +21,7 @@ def test_going_to_recharging_goes_to_recharge(events: Events) -> None:
 def test_home_goes_to_recharging_when_battery_low(events: Events) -> None:
     current_state = Home(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.battery_below_mission_threshold
+        events.async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())
@@ -35,7 +35,7 @@ def test_continuing_mission_when_battery_high(events: Events) -> None:
         events, mission=AbortedMission(name="test", id="test_id")
     )
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.battery_above_recharge_threshold
+        events.async_events.battery_above_recharge_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_return_home_paused_state.py
+++ b/tests/isar/state_machine/states/test_return_home_paused_state.py
@@ -40,7 +40,7 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
     current_state = ReturnHomePaused(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.api_requests.start_mission.request
+        events.async_events.mission_ready
     )
 
     example_mission: Mission = Mission(id="id", name="Dummy misson", tasks=[])
@@ -49,5 +49,5 @@ def test_transition_from_paused_return_home_to_stopping_paused_return_home_missi
 
     current_state = transition(events)
 
-    assert events.api_requests.start_mission.response.has_event()
+    assert events.api_requests.schedule_mission.response.has_event()
     assert current_state.name is States.StoppingPausedReturnHome

--- a/tests/isar/state_machine/states/test_returning_home_state.py
+++ b/tests/isar/state_machine/states/test_returning_home_state.py
@@ -70,11 +70,11 @@ def test_transition_from_returning_home_to_home_robot_status_not_updated(
 
     current_state = transition(events)
     assert current_state.name is States.Home
-    assert not events.robot_async_events.robot_status_update.check()
+    assert not events.async_events.robot_status_update.check()
 
     event_handler_robot_status: EventHandlerMapping = (
         current_state.get_event_handler_by_event(
-            events.robot_async_events.robot_status_update
+            events.async_events.robot_status_update
         )
     )
 

--- a/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
+++ b/tests/isar/state_machine/states/test_stopping_go_to_recharge_state.py
@@ -7,7 +7,7 @@ from isar.state_machine.states_enum import States
 def test_monitor_goes_to_return_home_when_battery_low(events: Events) -> None:
     current_state = Monitor(events, "mission_id")
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.battery_below_mission_threshold
+        events.async_events.battery_below_mission_threshold
     )
 
     transition = event_handler.handler(EmptyMessage())

--- a/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_paused_return_home_state.py
@@ -17,14 +17,14 @@ def test_transition_to_stopping_paused_return_home_replies_to_API(
     )
     current_state = ReturnHomePaused(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.api_requests.start_mission.request
+        events.async_events.mission_ready
     )
 
     transition = event_handler.handler(mission)
 
     current_state = transition(events)
     assert current_state.name is States.StoppingPausedReturnHome
-    assert events.api_requests.start_mission.response.has_event()
+    assert events.api_requests.schedule_mission.response.has_event()
 
 
 def test_stopping_paused_return_home_mission_fails(events: Events) -> None:
@@ -38,7 +38,7 @@ def test_stopping_paused_return_home_mission_fails(events: Events) -> None:
 
     transition = event_handler.handler(EmptyMessage())
 
-    assert not events.api_requests.start_mission.response.has_event()
+    assert not events.api_requests.schedule_mission.response.has_event()
 
     current_state = transition(events)
     assert current_state.name is States.InterventionNeeded

--- a/tests/isar/state_machine/states/test_stopping_return_home_state.py
+++ b/tests/isar/state_machine/states/test_stopping_return_home_state.py
@@ -12,7 +12,7 @@ def test_return_home_cancelled_when_new_mission_received(events: Events) -> None
     current_state = ReturningHome(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.api_requests.start_mission.request
+        events.async_events.mission_ready
     )
 
     mission: Mission = Mission(
@@ -31,14 +31,14 @@ def test_transition_to_stopping_return_home_replies_to_API(events: Events) -> No
     )
     current_state = ReturningHome(events)
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.api_requests.start_mission.request
+        events.async_events.mission_ready
     )
 
     transition = event_handler.handler(mission)
 
     current_state = transition(events)
     assert current_state.name is States.StoppingReturnHome
-    assert events.api_requests.start_mission.response.has_event()
+    assert events.api_requests.schedule_mission.response.has_event()
 
 
 def test_stopping_return_home_mission_fails(events: Events) -> None:
@@ -54,7 +54,7 @@ def test_stopping_return_home_mission_fails(events: Events) -> None:
         ErrorMessage(error_description="", error_reason=ErrorReason.RobotAPIException)
     )
 
-    assert not events.api_requests.start_mission.response.has_event()
+    assert not events.api_requests.schedule_mission.response.has_event()
 
     current_state = transition(events)
     assert current_state.name is States.ReturningHome

--- a/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
+++ b/tests/isar/state_machine/states/test_stopping_unknown_mission_state.py
@@ -49,7 +49,7 @@ def test_unknown_mission_successfully_aborted_on_isar_restart(events: Events) ->
     current_state: State = UnknownStatus(events)
 
     event_handler: EventHandlerMapping = current_state.get_event_handler_by_event(
-        events.robot_async_events.robot_status_update
+        events.async_events.robot_status_update
     )
 
     transition = event_handler.handler(RobotStatus.Busy)

--- a/tests/isar/state_machine/test_integration_test_for_states.py
+++ b/tests/isar/state_machine/test_integration_test_for_states.py
@@ -60,7 +60,7 @@ def test_state_machine_transitions_when_running_full_mission(
     )
     mission: Mission = Mission(id="id", name="Dummy mission", tasks=[task_1, task_2])
 
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
 
     expected_transitions = deque(
         [
@@ -107,7 +107,7 @@ def test_state_machine_failed_dependency(
         in state_machine_thread.state_machine.transitions_list,
         timeout=10,
     )
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
 
     expected_transitions = deque(
         [
@@ -158,7 +158,7 @@ def test_state_machine_with_successful_collection(
         lambda: States.Home in state_machine_thread.state_machine.transitions_list,
         timeout=10,
     )
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
 
     expected_transitions = deque(
         [
@@ -202,7 +202,7 @@ def test_state_machine_with_unsuccessful_collection(
     mission: Mission = Mission(
         id="id", name="Dummy misson", tasks=[StubTask.take_image()]
     )
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
 
     expected_transitions = deque(
         [
@@ -252,7 +252,7 @@ def test_state_machine_with_mission_start_during_return_home_without_queueing_st
         lambda: state_machine_thread.state_machine.current_state.name
         == States.ReturningHome
     )
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
     expected_transitions = deque(
         [
             States.UnknownStatus,
@@ -267,7 +267,7 @@ def test_state_machine_with_mission_start_during_return_home_without_queueing_st
         == expected_transitions
     )
     assert (
-        not state_machine_thread.state_machine.events.api_requests.start_mission.request.has_event()
+        not state_machine_thread.state_machine.events.async_events.mission_ready.has_event()
     )
 
 
@@ -301,7 +301,7 @@ def test_state_machine_failed_to_initiate_mission_and_return_home(
         timeout=10,
     )
 
-    scheduling_utilities.start_mission(mission=mission)
+    scheduling_utilities.schedule_mission(mission=mission)
 
     expected_transitions = deque(
         [

--- a/tests/test_mocks/mission_definition.py
+++ b/tests/test_mocks/mission_definition.py
@@ -1,10 +1,6 @@
-from isar.apis.models.models import (
-    InputOrientation,
-    InputPose,
-    InputPosition,
-    StartMissionResponse,
-    TaskResponse,
-)
+from alitra import Frame, Orientation, Pose, Position
+
+from isar.apis.models.models import StartMissionResponse, TaskResponse
 from isar.apis.models.start_mission_definition import (
     InspectionTypes,
     StartMissionDefinition,
@@ -16,14 +12,14 @@ from tests.test_mocks.task import StubTask
 
 
 class DummyMissionDefinition:
-    dummy_input_position = InputPosition(x=1, y=1, z=1, frame_name="robot")
-    dummy_input_orientation = InputOrientation(x=0, y=0, z=0, w=0, frame_name="robot")
-    dummy_input_pose = InputPose(
+    dummy_input_position = Position(x=1, y=1, z=1, frame=Frame("robot"))
+    dummy_input_orientation = Orientation(x=0, y=0, z=0, w=0, frame=Frame("robot"))
+    dummy_input_pose = Pose(
         position=dummy_input_position,
         orientation=dummy_input_orientation,
-        frame_name="robot",
+        frame=Frame("robot"),
     )
-    dummy_input_target_position = InputPosition(x=5, y=5, z=5, frame_name="robot")
+    dummy_input_target_position = Position(x=5, y=5, z=5, frame=Frame("robot"))
     dummy_task_take_image = StubTask.take_image()
     default_mission = Mission(
         id="default_mission",

--- a/tests/test_mocks/mission_definition.py
+++ b/tests/test_mocks/mission_definition.py
@@ -1,6 +1,6 @@
 from alitra import Frame, Orientation, Pose, Position
 
-from isar.apis.models.models import StartMissionResponse, TaskResponse
+from isar.apis.models.models import ScheduleMissionResponse, TaskResponse
 from isar.apis.models.start_mission_definition import (
     InspectionTypes,
     StartMissionDefinition,
@@ -44,7 +44,7 @@ class DummyMissionDefinition:
         type=dummy_task_take_image.type,
     )
 
-    dummy_start_mission_response = StartMissionResponse(
+    dummy_start_mission_response = ScheduleMissionResponse(
         id=default_mission.id,
         tasks=[dummy_task_response_take_image],
     )

--- a/tests/test_mocks/mission_definition.py
+++ b/tests/test_mocks/mission_definition.py
@@ -8,7 +8,6 @@ from isar.apis.models.models import (
 from isar.apis.models.start_mission_definition import (
     InspectionTypes,
     StartMissionDefinition,
-    StartMissionInspectionDefinition,
     StartMissionTaskDefinition,
 )
 from robot_interface.models.mission.mission import Mission
@@ -42,16 +41,6 @@ class DummyMissionDefinition:
         ],
         status=MissionStatus.Cancelled,
     )
-    dummy_start_mission_inspection_definition = StartMissionInspectionDefinition(
-        type=InspectionTypes.image,
-        inspection_target=dummy_input_target_position,
-    )
-    dummy_start_mission_inspection_definition_thermal_image = (
-        StartMissionInspectionDefinition(
-            type=InspectionTypes.thermal_image,
-            inspection_target=dummy_input_target_position,
-        )
-    )
     dummy_task_response_take_image = TaskResponse(
         id=dummy_task_take_image.id,
         tag_id=dummy_task_take_image.tag_id,
@@ -70,7 +59,8 @@ class DummyMissionDefinition:
                 id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
-                inspection=dummy_start_mission_inspection_definition,
+                type=InspectionTypes.image,
+                inspection_target=dummy_input_target_position,
             ),
         ],
     )
@@ -81,13 +71,15 @@ class DummyMissionDefinition:
                 id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
-                inspection=dummy_start_mission_inspection_definition,
+                type=InspectionTypes.image,
+                inspection_target=dummy_input_target_position,
             ),
             StartMissionTaskDefinition(
                 id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
-                inspection=dummy_start_mission_inspection_definition_thermal_image,
+                type=InspectionTypes.thermal_image,
+                inspection_target=dummy_input_target_position,
             ),
         ],
     )
@@ -98,19 +90,22 @@ class DummyMissionDefinition:
                 id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
-                inspection=dummy_start_mission_inspection_definition,
+                type=InspectionTypes.image,
+                inspection_target=dummy_input_target_position,
             ),
             StartMissionTaskDefinition(
                 id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
-                inspection=dummy_start_mission_inspection_definition,
+                type=InspectionTypes.image,
+                inspection_target=dummy_input_target_position,
             ),
             StartMissionTaskDefinition(
                 id="dummy_id",
                 pose=dummy_input_pose,
                 tag="dummy_tag",
-                inspection=dummy_start_mission_inspection_definition,
+                type=InspectionTypes.image,
+                inspection_target=dummy_input_target_position,
             ),
         ],
     )

--- a/tests/test_mocks/state_machine_mocks.py
+++ b/tests/test_mocks/state_machine_mocks.py
@@ -2,22 +2,28 @@ from threading import Thread
 
 from isar.modules import ApplicationContainer
 from isar.robot.robot_service import RobotService
+from isar.services.mission_queue.mission_queue_service import MissionQueueService
 from isar.state_machine.state_machine import StateMachine
 
 
 class StateMachineThreadMock:
     def __init__(self, container: ApplicationContainer) -> None:
         self.state_machine: StateMachine = container.state_machine()
+        self._mission_queue_thread: MissionQueueService = MissionQueueService(
+            self.state_machine.events
+        )
         self._thread: Thread = Thread(
             name="State machine mock", target=self.state_machine.run
         )
 
     def start(self) -> None:
+        self._mission_queue_thread.start()
         self._thread.start()
 
     def join(self) -> None:
         self.state_machine.terminate()
         self._thread.join()
+        self._mission_queue_thread.join()
 
 
 class RobotServiceThreadMock:

--- a/tests/test_persistent_memory.py
+++ b/tests/test_persistent_memory.py
@@ -80,7 +80,7 @@ def test_lockdown_mode(
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
     wait_until(
-        lambda: state_machine_thread_with_db.state_machine.events.robot_async_events.robot_status_update.check()
+        lambda: state_machine_thread_with_db.state_machine.events.async_events.robot_status_update.check()
         == RobotStatus.Home,
         timeout=10.0,
     )
@@ -96,7 +96,7 @@ def test_lockdown_mode(
         StubRobot, "mission_status", return_value=MissionStatus.InProgress
     )  # The robot will not go to awaiting next mission after mission has started, it should remain in monitor. In order to test the "stop" functionality.
     response = client.post(
-        url="/schedule/start-mission",
+        url="/schedule/schedule-mission",
         json=jsonable_encoder(
             {
                 "mission_definition": DummyMissionDefinition.dummy_start_mission_definition
@@ -105,9 +105,12 @@ def test_lockdown_mode(
     )
     assert response.status_code == HTTPStatus.OK
 
-    assert (
-        state_machine_thread_with_db.state_machine.current_state.name == States.Monitor
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.current_state.name
+        == States.Monitor,
+        timeout=5.0,
     )
+
     response = client.post(url="/schedule/lockdown")
     assert response.status_code == HTTPStatus.OK
 
@@ -120,16 +123,6 @@ def test_lockdown_mode(
         == States.Lockdown,
         timeout=10.0,
     )
-
-    response = client.post(
-        url="/schedule/start-mission",
-        json=jsonable_encoder(
-            {
-                "mission_definition": DummyMissionDefinition.dummy_start_mission_definition
-            }
-        ),
-    )
-    assert response.status_code == HTTPStatus.CONFLICT
 
     expected_transitions = deque(
         [
@@ -168,20 +161,9 @@ def test_maintenance_mode(
         == States.Maintenance
     )
 
-    # The robot should have started in maintenance mode since the robot id is not found in the database.
-    response = client.post(
-        url="/schedule/start-mission",
-        json=jsonable_encoder(
-            {
-                "mission_definition": DummyMissionDefinition.dummy_start_mission_definition
-            }
-        ),
-    )
-    assert response.status_code == HTTPStatus.CONFLICT
-
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
     wait_until(
-        lambda: state_machine_thread_with_db.state_machine.events.robot_async_events.robot_status_update.check()
+        lambda: state_machine_thread_with_db.state_machine.events.async_events.robot_status_update.check()
         == RobotStatus.Home,
         timeout=10.0,
     )
@@ -197,7 +179,7 @@ def test_maintenance_mode(
         StubRobot, "mission_status", return_value=MissionStatus.InProgress
     )  # The robot will not go to awaitng next mission after mission has started, it should remain in monitor. In order to test the "stop" functionality.
     response = client.post(
-        url="/schedule/start-mission",
+        url="/schedule/schedule-mission",
         json=jsonable_encoder(
             {
                 "mission_definition": DummyMissionDefinition.dummy_start_mission_definition
@@ -206,21 +188,14 @@ def test_maintenance_mode(
     )
     assert response.status_code == HTTPStatus.OK
 
-    assert (
-        state_machine_thread_with_db.state_machine.current_state.name == States.Monitor
+    wait_until(
+        lambda: state_machine_thread_with_db.state_machine.current_state.name
+        == States.Monitor,
+        timeout=5.0,
     )
+
     response = client.post(url="/schedule/maintenance-mode")
     assert response.status_code == HTTPStatus.OK
-
-    response = client.post(
-        url="/schedule/start-mission",
-        json=jsonable_encoder(
-            {
-                "mission_definition": DummyMissionDefinition.dummy_start_mission_definition
-            }
-        ),
-    )
-    assert response.status_code == HTTPStatus.CONFLICT
 
     expected_transitions = deque(
         [
@@ -256,7 +231,7 @@ def test_release_maintenance_mode(
 
     mocker.patch.object(StubRobot, "robot_status", return_value=RobotStatus.Home)
     wait_until(
-        lambda: state_machine_thread_with_db.state_machine.events.robot_async_events.robot_status_update.check()
+        lambda: state_machine_thread_with_db.state_machine.events.async_events.robot_status_update.check()
         == RobotStatus.Home,
         timeout=10.0,
     )


### PR DESCRIPTION
Closes #1182 

Pending https://github.com/equinor/isar/pull/1196

Personal TODO before merging:
- add tests for the function that adds missions to the queue
- add test for going past the maximum queue length
- implement simple insertion sort for appending missions to the queue
- avoid the timer in await next mission, and instead transition from monitor to monitor if there is a pending mission
- implement Flotilla changes

Breaking changes:
- "/start-mission" endpoint changed to "/schedule-mission"
- mission is not guaranteed to have started by the time the API call returns
- the mission queue is reported on a new MQTT topic "/mission_queue"

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like logging, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that requires new issues
- [ ] The changes do not introduce dead code as unused imports, functions etc.